### PR TITLE
Remove fastgltf submodule and fetch on-demand during build

### DIFF
--- a/Tools/Dependencies/Build-FastGltf.ps1
+++ b/Tools/Dependencies/Build-FastGltf.ps1
@@ -1,0 +1,56 @@
+param(
+    [string]$Rid = "win-x64",
+    [string]$Configuration = "Release",
+    [switch]$ForceBuild
+)
+
+$ErrorActionPreference = "Stop"
+
+$root = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$sourceDir = Join-Path $root "Build\ThirdParty\fastgltf"
+
+if (-not (Test-Path $sourceDir)) {
+    Write-Host "fastgltf source not found; cloning into '$sourceDir'." -ForegroundColor Yellow
+    $sourceRoot = Split-Path -Parent $sourceDir
+    if (-not (Test-Path $sourceRoot)) {
+        New-Item -ItemType Directory -Path $sourceRoot | Out-Null
+    }
+    git clone --depth 1 https://github.com/spnda/fastgltf.git $sourceDir
+    if ($LASTEXITCODE -ne 0) { throw "fastgltf clone failed." }
+}
+
+$buildDir = Join-Path $sourceDir "build-$Rid-$Configuration"
+$runtimeDir = Join-Path $root "XRENGINE\runtimes\$Rid\native"
+
+if (-not (Test-Path $runtimeDir)) {
+    New-Item -ItemType Directory -Path $runtimeDir | Out-Null
+}
+
+$cmakeArgs = @(
+    "-S", $sourceDir,
+    "-B", $buildDir,
+    "-DFASTGLTF_ENABLE_TESTS=OFF",
+    "-DFASTGLTF_ENABLE_EXAMPLES=OFF",
+    "-DFASTGLTF_ENABLE_DOCS=OFF",
+    "-DBUILD_SHARED_LIBS=ON"
+)
+
+if ($ForceBuild -or -not (Test-Path $buildDir)) {
+    & cmake @cmakeArgs
+    if ($LASTEXITCODE -ne 0) { throw "CMake configure failed." }
+}
+
+& cmake --build $buildDir --config $Configuration
+if ($LASTEXITCODE -ne 0) { throw "CMake build failed." }
+
+$dllPath = Join-Path $buildDir "$Configuration\fastgltf.dll"
+if (-not (Test-Path $dllPath)) {
+    $dllPath = Join-Path $buildDir "fastgltf.dll"
+}
+
+if (-not (Test-Path $dllPath)) {
+    throw "fastgltf.dll not found in build output at '$buildDir'."
+}
+
+Copy-Item -Path $dllPath -Destination (Join-Path $runtimeDir "fastgltf.dll") -Force
+Write-Host "Copied fastgltf.dll to $runtimeDir" -ForegroundColor Green

--- a/XRENGINE/EditorPreferences.cs
+++ b/XRENGINE/EditorPreferences.cs
@@ -23,6 +23,7 @@ namespace XREngine
         private int _scenePanelResizeDebounceMs = 0;
         private EditorThemeSettings _theme = new();
         private EditorDebugOptions _debug = new();
+        private bool _preferFastGltfForGltf = true;
         private bool _mcpServerEnabled = false;
         private int _mcpServerPort = 5467;
 
@@ -40,6 +41,14 @@ namespace XREngine
         {
             get => _debug;
             set => SetField(ref _debug, value ?? new EditorDebugOptions());
+        }
+
+        [Category("Import")]
+        [Description("Prefer the fastgltf importer for .gltf/.glb files when available.")]
+        public bool PreferFastGltfForGltf
+        {
+            get => _preferFastGltfForGltf;
+            set => SetField(ref _preferFastGltfForGltf, value);
         }
 
         /// <summary>
@@ -94,6 +103,7 @@ namespace XREngine
 
             Theme.CopyFrom(source.Theme);
             Debug.CopyFrom(source.Debug);
+            PreferFastGltfForGltf = source.PreferFastGltfForGltf;
             ViewportPresentationMode = source.ViewportPresentationMode;
             ScenePanelResizeDebounceMs = source.ScenePanelResizeDebounceMs;
             McpServerEnabled = source.McpServerEnabled;
@@ -107,6 +117,9 @@ namespace XREngine
 
             Theme.ApplyOverrides(overrides.Theme);
             Debug.ApplyOverrides(overrides.Debug);
+
+            if (overrides.PreferFastGltfForGltfOverride is { HasOverride: true } preferFastGltfOverride)
+                PreferFastGltfForGltf = preferFastGltfOverride.Value;
 
             if (overrides.ViewportPresentationModeOverride is { HasOverride: true } vpOverride)
                 ViewportPresentationMode = vpOverride.Value;

--- a/XRENGINE/EditorPreferencesOverrides.cs
+++ b/XRENGINE/EditorPreferencesOverrides.cs
@@ -15,6 +15,7 @@ namespace XREngine
     {
         private EditorThemeOverrides _theme = new();
         private EditorDebugOverrides _debug = new();
+        private OverrideableSetting<bool> _preferFastGltfForGltfOverride = new();
         private OverrideableSetting<EditorPreferences.EViewportPresentationMode> _viewportPresentationModeOverride = new();
         private OverrideableSetting<int> _scenePanelResizeDebounceMsOverride = new();
         private OverrideableSetting<bool> _mcpServerEnabledOverride = new();
@@ -34,6 +35,14 @@ namespace XREngine
         {
             get => _debug;
             set => SetField(ref _debug, value ?? new EditorDebugOverrides());
+        }
+
+        [Category("Import Overrides")]
+        [Description("Override for preferring fastgltf over Assimp for glTF imports.")]
+        public OverrideableSetting<bool> PreferFastGltfForGltfOverride
+        {
+            get => _preferFastGltfForGltfOverride;
+            set => SetField(ref _preferFastGltfForGltfOverride, value ?? new());
         }
 
         [Category("Viewport Overrides")]

--- a/XRENGINE/FastGltfImporter.cs
+++ b/XRENGINE/FastGltfImporter.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using XREngine.Rendering;
+using XREngine.Rendering.Models;
+using XREngine.Rendering.Models.Materials;
+using XREngine.Scene;
+
+namespace XREngine
+{
+    internal static class FastGltfImporter
+    {
+        private const string FastGltfLibraryName = "fastgltf";
+        private static bool? _isAvailable;
+
+        public static bool IsAvailable
+        {
+            get
+            {
+                if (_isAvailable.HasValue)
+                    return _isAvailable.Value;
+
+                if (NativeLibrary.TryLoad(FastGltfLibraryName, out IntPtr handle))
+                {
+                    NativeLibrary.Free(handle);
+                    _isAvailable = true;
+                }
+                else
+                {
+                    _isAvailable = false;
+                }
+
+                return _isAvailable.Value;
+            }
+        }
+
+        public static bool IsGltfFile(string filePath)
+        {
+            string ext = Path.GetExtension(filePath);
+            return ext.Equals(".gltf", StringComparison.OrdinalIgnoreCase)
+                || ext.Equals(".glb", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool ShouldUseFastGltf(string filePath)
+            => IsGltfFile(filePath) && (Engine.EditorPreferences?.PreferFastGltfForGltf ?? false);
+
+        public static bool TryImport(
+            string filePath,
+            ModelImportOptions options,
+            out SceneNode? rootNode,
+            out IReadOnlyCollection<XRMaterial> materials,
+            out IReadOnlyCollection<XRMesh> meshes)
+        {
+            rootNode = null;
+            materials = Array.Empty<XRMaterial>();
+            meshes = Array.Empty<XRMesh>();
+
+            if (!IsAvailable)
+            {
+                Debug.Out($"[FastGltfImporter] fastgltf native library not available; falling back to Assimp for '{filePath}'.");
+                return false;
+            }
+
+            Debug.LogWarning("fastgltf backend is not yet wired into the engine; falling back to Assimp for glTF import.");
+            return false;
+        }
+    }
+}

--- a/XRENGINE/Scene/Prefabs/XRPrefabSource.cs
+++ b/XRENGINE/Scene/Prefabs/XRPrefabSource.cs
@@ -146,6 +146,14 @@ namespace XREngine.Scene.Prefabs
 
             var opts = importOptions as ModelImportOptions ?? new ModelImportOptions();
 
+            if (FastGltfImporter.ShouldUseFastGltf(filePath)
+                && FastGltfImporter.TryImport(filePath, opts, out SceneNode? fastNode, out _, out _))
+            {
+                RootNode = fastNode;
+                Name ??= Path.GetFileNameWithoutExtension(filePath);
+                return RootNode is not null;
+            }
+
             using var importer = new ModelImporter(filePath, onCompleted: null, materialFactory: null);
 
             // Preserve the importer's default texture factory (it sets FilePath + schedules actual loads)

--- a/XRENGINE/XREngine.csproj
+++ b/XRENGINE/XREngine.csproj
@@ -16,6 +16,10 @@
     <CoACDRid Condition="'$(CoACDRid)' == '' and '$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</CoACDRid>
     <CoACDRid Condition="'$(CoACDRid)' == ''">win-x64</CoACDRid>
     <ForceCoACDBuildSwitch Condition="'$(ForceCoACDBuild)' == 'true'">-ForceBuild</ForceCoACDBuildSwitch>
+    <FastGltfBuildScript Condition="'$(FastGltfBuildScript)' == ''">$(SolutionDir)Tools\Dependencies\Build-FastGltf.ps1</FastGltfBuildScript>
+    <FastGltfRid Condition="'$(FastGltfRid)' == '' and '$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</FastGltfRid>
+    <FastGltfRid Condition="'$(FastGltfRid)' == ''">win-x64</FastGltfRid>
+    <ForceFastGltfBuildSwitch Condition="'$(ForceFastGltfBuild)' == 'true'">-ForceBuild</ForceFastGltfBuildSwitch>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -254,6 +258,9 @@
     <None Update="runtimes\win-x64\native\libmagicphysx.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="runtimes\win-x64\native\fastgltf.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="runtimes\win-x64\native\nis.license.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -296,6 +303,11 @@
   <Target Name="EnsureCoACD" BeforeTargets="PrepareForBuild" Condition="'$(OS)' == 'Windows_NT' and Exists('$(CoACDBuildScript)') and ('$(CoACDRid)' != '') and ('$(ForceCoACDBuild)' == 'true' or !Exists('$(MSBuildProjectDirectory)\\runtimes\\$(CoACDRid)\\native\\lib_coacd.dll'))">
     <Message Text="Ensuring CoACD native library ($(CoACDRid))" Importance="High" />
     <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(CoACDBuildScript)&quot; -Rid $(CoACDRid) -Ref $(CoACDRef) -Configuration $(Configuration) $(ForceCoACDBuildSwitch)" />
+  </Target>
+
+  <Target Name="EnsureFastGltf" BeforeTargets="PrepareForBuild" Condition="'$(OS)' == 'Windows_NT' and Exists('$(FastGltfBuildScript)') and ('$(FastGltfRid)' != '') and ('$(ForceFastGltfBuild)' == 'true' or !Exists('$(MSBuildProjectDirectory)\\runtimes\\$(FastGltfRid)\\native\\fastgltf.dll'))">
+    <Message Text="Ensuring fastgltf native library ($(FastGltfRid))" Importance="High" />
+    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(FastGltfBuildScript)&quot; -Rid $(FastGltfRid) -Configuration $(Configuration) $(ForceFastGltfBuildSwitch)" />
   </Target>
 
   <Target Name="ForceFreetype64" AfterTargets="Build" Condition="Exists('$(Freetype64Source)')">

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -23,6 +23,8 @@ Notes:
 | Name | Used by | Owner | License (best-effort) | URL |
 |---|---|---|---|---|
 | CDT | CoACD | artem-ogre | [(unknown)](licenses/unknown/nested-CDT.txt) | https://github.com/artem-ogre/CDT |
+| fastgltf | Build-FastGltf.ps1 | spnda | [MIT](licenses/submodules/fastgltf-MIT.txt) | https://github.com/spnda/fastgltf |
+| simdjson | fastgltf | simdjson | [Apache-2.0](licenses/unknown/nested-simdjson-Apache-2.0.txt) | https://github.com/simdjson/simdjson |
 
 ## NuGet packages (direct)
 | Package | Version(s) | Owner (best-effort) | License (best-effort) | Used by |

--- a/docs/licenses/submodules/fastgltf-MIT.txt
+++ b/docs/licenses/submodules/fastgltf-MIT.txt
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2022 - 2026 Sean Apeler.
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/docs/licenses/unknown/nested-simdjson-Apache-2.0.txt
+++ b/docs/licenses/unknown/nested-simdjson-Apache-2.0.txt
@@ -1,0 +1,74 @@
+simdjson
+https://github.com/simdjson/simdjson
+
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   Copyright 2009-2024 The simdjson authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
### Motivation
- Avoid keeping the `fastgltf` repository as a checked-in git submodule and instead fetch the source on-demand during the build to simplify repo maintenance.
- Keep the editor/import wiring and dependency tracking for `fastgltf` intact while allowing builds to obtain the native library as needed.

### Description
- Removed the `Build/Submodules/fastgltf` gitlink and deleted the submodule entry from `.gitmodules` so `fastgltf` is no longer tracked as a submodule.
- Updated `Tools/Dependencies/Build-FastGltf.ps1` to clone `https://github.com/spnda/fastgltf.git` into `Build\ThirdParty\fastgltf` when the source is missing and then configure/build/copy `fastgltf.dll` into `runtimes\win-x64\native`.
- Updated `docs/DEPENDENCIES.md` to reflect that `fastgltf` is now a fetched build dependency (and documented `simdjson` as its nested dependency). 
- Ensured project build wiring for the native DLL is present via added `XRENGINE.csproj` entries so the `fastgltf` build target and runtime copy are triggered when needed.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69769b1ba270832d904458a5fa8b7609)