### PR TITLE
docs(texturing): define cross-API sparse residency and SVT guidance

### DIFF
--- a/docs/work/design/texturing/sparse-residency-and-svt-backend-guide.md
+++ b/docs/work/design/texturing/sparse-residency-and-svt-backend-guide.md
@@ -1,0 +1,695 @@
+# Sparse Residency And Streaming Virtual Texturing Backend Guide
+
+Last Updated: 2026-09-02
+Status: canonical companion design
+Scope: normative OpenGL and Vulkan sparse-residency behavior, portable streaming virtual texture architecture, synchronization, physical-cache ownership, filtering, feedback, VR prioritization, and validation.
+
+Related documents:
+
+- [Texture Runtime, Streaming, And Virtual Texturing Design](texture-runtime-streaming-virtual-texturing-design.md)
+- [Texture Runtime, Streaming, And Virtual Texturing TODO](../../todo/texturing/texture-runtime-streaming-virtual-texturing-todo.md)
+- [Texture Compression And Cooked Texture Cache Design](texture-compression-and-cooked-cache-design.md)
+- [Sparse Texture Streaming Plan](sparse-texture-streaming-plan.md) *(historical implementation ledger)*
+
+Normative external references:
+
+- [GL_ARB_sparse_texture](https://registry.khronos.org/OpenGL/extensions/ARB/ARB_sparse_texture.txt)
+- [GL_ARB_sparse_texture2](https://registry.khronos.org/OpenGL/extensions/ARB/ARB_sparse_texture2.txt)
+- [Vulkan sparse resources](https://docs.vulkan.org/spec/latest/chapters/sparsemem.html)
+- [Vulkan image resources and subresources](https://docs.vulkan.org/spec/latest/chapters/resources.html)
+
+## 1. Purpose
+
+XRENGINE already has two useful texture-streaming implementations:
+
+- OpenGL dense/tiered mip streaming plus hardware sparse whole-mip residency.
+- Vulkan dense, generation-gated, synchronized mip uploads with deferred descriptor publication and resource retirement.
+
+Neither implementation is a complete streaming virtual texture system. This guide defines the exact boundary between mip streaming, hardware sparse residency, software-indirected streaming virtual texturing, and runtime-generated virtual texturing. It also specifies the synchronization and publication rules that future backends must follow.
+
+The portable production target is a software-indirected streaming virtual texture system built around page-addressable cooked assets, dense physical tile caches, virtual page tables, GPU feedback, and ancestor fallback. Hardware sparse resources are optional backend optimizations. They are not the cross-API asset or shader contract.
+
+## 2. Terminology And Feature Tiers
+
+### 2.1 Dense mip streaming
+
+A texture is represented by an ordinary fully backed image containing only the selected resident mip range. Promotion or demotion can recreate the image, upload a replacement image, or republish a different image view or descriptor.
+
+This is the current Vulkan path and the OpenGL compatibility path.
+
+### 2.2 Hardware sparse mip residency
+
+One stable logical image exposes the complete authored dimensions and mip count, but only selected complete mips are physically committed. Sampling is clamped to the committed range.
+
+This is the current preferred OpenGL path for eligible textures.
+
+### 2.3 Hardware sparse page residency
+
+Individual hardware-defined regions inside a sparse mip are committed and uncommitted. The page geometry is device-, API-, target-, and format-dependent. Hardware page commitment alone does not provide a virtual page table, tile borders, filtering across page boundaries, disk addressing, feedback, or an ancestor fallback policy.
+
+XRENGINE has OpenGL region-selection and commit scaffolding, but policy keeps it disabled by default.
+
+### 2.4 Streaming virtual texturing (SVT)
+
+A logical texture is divided into engine-defined pages. A virtual page table maps logical page identifiers to slots in a physical tile cache. GPU feedback requests missing pages, the streamer loads page-addressable cooked blobs, and shaders fall back to a resident ancestor until the requested page is safely published.
+
+This is not implemented yet.
+
+### 2.5 Runtime virtual texturing (RVT)
+
+RVT uses the same logical-page, physical-cache, page-table, and eviction concepts as SVT, but page content is rendered or generated at runtime instead of loaded from cooked files.
+
+This belongs after the shared SVT cache and page-table infrastructure is stable.
+
+## 3. Current Backend Capability Matrix
+
+| Capability | OpenGL | Vulkan |
+|---|---:|---:|
+| Dense/tiered mip streaming | Implemented | Implemented |
+| Generation-gated asynchronous preparation | Implemented | Implemented |
+| GPU-completion-gated publication | Implemented for shared-context sparse promotion | Implemented for dense descriptor publication |
+| Hardware sparse whole-mip residency | Implemented for eligible `Rgba8` `XRTexture2D` assets | Not implemented |
+| Hardware sparse partial-page residency | Scaffolded; disabled by policy | Not implemented |
+| Page-addressable cooked payload | Not implemented | Not implemented |
+| Shared physical tile cache | Not implemented | Not implemented |
+| Virtual page table | Not implemented | Not implemented |
+| GPU page feedback and resolve | Not implemented | Not implemented |
+| Full SVT | Not implemented | Not implemented |
+| RVT page production | Not implemented | Not implemented |
+
+## 4. Cross-API Invariants
+
+### 4.1 Stable logical identity
+
+Materials retain a stable logical texture or virtual-texture identity. Backend storage, committed pages, image handles, descriptors, cache slots, and page-table generations may change underneath that identity.
+
+### 4.2 Never expose incomplete data
+
+A finer mip, sparse page, physical tile, image generation, or page-table mapping becomes shader-visible only after all required memory binding, data upload, barriers, and cross-queue or cross-context synchronization have completed.
+
+### 4.3 Revoke before reuse
+
+A physical page or cache slot cannot be rebound or reused until:
+
+1. every page-table or descriptor mapping that references it has been replaced with a valid fallback;
+2. every submitted frame that could observe the old mapping has retired; and
+3. any API-specific sparse unbind has completed.
+
+### 4.4 Always-resident fallback
+
+Every streamable texture keeps a valid coarse fallback. For sparse mip streaming this is the committed mip tail or a pinned coarse range. For SVT this is a pinned ancestor page chain or compact fallback mip atlas.
+
+Correctness must not depend on the value returned by a nonresident hardware sparse read.
+
+### 4.5 Generation-gated work
+
+Every I/O request, decode/transcode result, memory bind, upload, page-table publication, and eviction captures the relevant texture, cache, and storage generations. Stale work is canceled or discarded before publication.
+
+### 4.6 Renderer-neutral policy
+
+Policy deals in logical dimensions, logical pages, resident quality, estimated or exact physical bytes, priority, deadline class, source version, and completion tickets. OpenGL handles, Vulkan handles, image layouts, memory offsets, extension enums, and queue-family indices remain below backend interfaces.
+
+### 4.7 No blocking hot-path readback
+
+GPU feedback readback uses a ring and intentional latency. Rendering never waits synchronously for page requests. Feedback latency is hidden with coarse fallback, neighborhood expansion, velocity prediction, and hysteresis.
+
+## 5. OpenGL Hardware Sparse Residency Contract
+
+### 5.1 Capability probing
+
+Probe `GL_ARB_sparse_texture` and `GL_ARB_sparse_texture2` during renderer initialization. Sparse support must be queried for each exact texture target and sized internal format that the backend intends to use.
+
+For every target/format pair:
+
+1. query `GL_NUM_VIRTUAL_PAGE_SIZES_ARB` with `glGetInternalformativ`;
+2. if the result is zero, mark that pair unsupported;
+3. query the complete corresponding arrays for:
+   - `GL_VIRTUAL_PAGE_SIZE_X_ARB`;
+   - `GL_VIRTUAL_PAGE_SIZE_Y_ARB`;
+   - `GL_VIRTUAL_PAGE_SIZE_Z_ARB`;
+4. choose and retain a page-size index through an explicit backend policy;
+5. report the selected index and geometry through diagnostics.
+
+Do not assume that every format uses 64x64 or 128x128 pages. `GL_ARB_sparse_texture2` standardizes index-zero page sizes for several uncompressed formats, but compressed formats and other layouts remain query-driven.
+
+### 5.2 Page-layout selection
+
+The first nonzero layout is a functional fallback, not a complete policy. Selection should consider:
+
+- the engine logical tile interior size;
+- physical page count per upload;
+- edge waste and partial-edge behavior;
+- format block geometry;
+- expected filtering footprint;
+- driver validation results;
+- and whether index zero is the standardized sparse-texture2 layout for the format.
+
+The selected layout is backend state. It must not be written into the portable cooked asset as the logical page size.
+
+### 5.3 Sparse immutable storage creation
+
+The creation order is mandatory:
+
+1. create or generate the texture object;
+2. set `GL_TEXTURE_SPARSE_ARB = GL_TRUE`;
+3. set `GL_VIRTUAL_PAGE_SIZE_INDEX_ARB` to the chosen index;
+4. allocate the full logical immutable storage with `glTextureStorage2D` or the equivalent target-specific call;
+5. query `GL_NUM_SPARSE_LEVELS_ARB` from the created texture;
+6. commit and upload a valid fallback range before exposing the texture to materials.
+
+Sparse flags cannot be retrofitted after immutable storage exists. A texture that already owns incompatible dense storage must be recreated before entering the sparse path.
+
+### 5.4 Base-dimension eligibility
+
+With base `GL_ARB_sparse_texture`, the logical allocation must satisfy the extension's sparse page-alignment restrictions. Textures that do not satisfy them use the dense/tiered fallback.
+
+When `GL_ARB_sparse_texture2` is present, arbitrary base dimensions may be accepted. Individual commitments must still use page-aligned origins and page-sized extents, except where an extent reaches the edge of a mip according to the extension rules.
+
+XRENGINE currently applies the conservative base-extension alignment gate even when sparse-texture2 is available. Relaxing that gate is a separate implementation task and requires dedicated edge-commit validation.
+
+### 5.5 Mip tail
+
+`GL_NUM_SPARSE_LEVELS_ARB` is the first mip level in the opaque mip tail. Mips below that index are independently sparse-manageable; the tail is committed or uncommitted as one atomic region.
+
+The backend must:
+
+- query the tail boundary per texture allocation;
+- pin the tail or another complete coarse fallback before sampling;
+- never estimate the tail boundary from dimensions alone;
+- and never attempt to treat tail mips as independent pages.
+
+### 5.6 Promotion sequence
+
+A whole-mip or page promotion follows this order:
+
+```text
+Resolve page-aligned physical coverage
+→ commit pages with glTexPageCommitmentARB
+→ upload every texel that may be sampled
+→ insert a GL sync object when work occurs on a shared context
+→ flush the producer context
+→ wait or poll from the render context
+→ verify storage generation
+→ expose the finer base mip or publish the new virtual mapping
+```
+
+Newly committed memory has undefined contents. Commitment is not initialization.
+
+For shared-context uploads, `glFenceSync` plus `glFlush` on the producer context and `glClientWaitSync` or `glWaitSync` on the consumer context form the publication boundary. The render thread must not lower `GL_TEXTURE_BASE_LEVEL` before that boundary completes.
+
+### 5.7 Demotion and eviction sequence
+
+Whole-mip demotion follows this order:
+
+```text
+Ensure a coarser range is populated
+→ raise GL_TEXTURE_BASE_LEVEL
+→ retire draws that may still sample the finer range
+→ uncommit the inaccessible finer pages
+```
+
+SVT cache eviction follows the cross-API mapping sequence instead:
+
+```text
+Publish ancestor mapping
+→ retire old frames/page-table versions
+→ uncommit optional sparse cache backing
+→ release physical slot
+```
+
+### 5.8 Nonresident sampling
+
+Base `GL_ARB_sparse_texture` does not provide a portable material value for nonresident reads. `GL_ARB_sparse_texture2` defines zero-like behavior for nonresident components and adds sparse residency-query operations, but zero is still not a valid universal material fallback.
+
+Examples of invalid zero fallback include black albedo, zero opacity, invalid tangent normals, and unintended mirror-like roughness. Shaders must sample only committed data or resolve missing virtual pages to valid resident ancestors.
+
+### 5.9 Compressed formats
+
+Sparse compressed texture support does not universally require `GL_ARB_sparse_texture2`. It is implementation-dependent and must be queried for the exact compressed internal format using `GL_NUM_VIRTUAL_PAGE_SIZES_ARB`.
+
+The backend policy is:
+
+- use sparse BCn only when the exact format reports usable page layouts and validation passes;
+- retain dense BCn cache banks as the normal portable SVT path;
+- retain an uncompressed portable fallback where required;
+- keep block-aligned page offsets, extents, and stored dimensions;
+- and use compressed subimage upload calls for precompressed cooked pages.
+
+### 5.10 Diagnostics and byte accounting
+
+`glTexPageCommitmentARB` submission is not proof that a transition was valid. Debug builds should use `KHR_debug` and log the target, format, mip, rectangle, selected page geometry, storage generation, and transition generation for every failure.
+
+Avoid hot-path `glGetError` polling in release builds.
+
+OpenGL committed bytes are generally an estimate because opaque tail allocation, page padding, and driver allocation behavior are not fully exposed. Telemetry should distinguish:
+
+- logical payload bytes;
+- estimated sparse physical bytes;
+- exact dense physical-cache bytes;
+- and driver-reported global memory pressure where available.
+
+## 6. Vulkan Hardware Sparse Residency Contract
+
+### 6.1 Device and queue capability probing
+
+Before enabling a Vulkan sparse backend, require:
+
+- `sparseBinding`;
+- `sparseResidencyImage2D` for 2D textures;
+- an appropriate queue family with `VK_QUEUE_SPARSE_BINDING_BIT`;
+- support for the exact format, image type, tiling, usage, sample count, and creation flags;
+- and `shaderResourceResidency` only when shaders will query sparse residency directly.
+
+Use `vkGetPhysicalDeviceSparseImageFormatProperties2` for every intended image configuration. A zero property count means that configuration is unsupported and must use a dense fallback.
+
+Do not require a dedicated sparse queue. A combined graphics/sparse queue is valid, but sparse binding remains explicitly synchronized queue work even when the same queue performs subsequent copies or rendering.
+
+### 6.2 Sparse image creation
+
+A sampled sparse image normally uses:
+
+```text
+VK_IMAGE_CREATE_SPARSE_BINDING_BIT
+VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT
+VK_IMAGE_USAGE_SAMPLED_BIT
+VK_IMAGE_USAGE_TRANSFER_DST_BIT
+VK_IMAGE_TILING_OPTIMAL
+```
+
+Only add `VK_IMAGE_CREATE_SPARSE_ALIASED_BIT` when the design intentionally aliases the same memory across sparse resources and the device exposes the corresponding feature. Initial implementations should avoid sparse aliasing.
+
+### 6.3 Memory requirements, mip tails, and metadata
+
+After image creation, query:
+
+- `vkGetImageMemoryRequirements2` for allocation size/alignment and memory types;
+- `vkGetImageSparseMemoryRequirements2` for sparse granularity, mip-tail layout, per-layer tail stride, single-tail behavior, and metadata requirements.
+
+Non-tail regions use `VkSparseImageMemoryBind` in `VkSparseImageMemoryBindInfo`.
+
+Mip tails use opaque memory binds through `VkSparseImageOpaqueMemoryBindInfo`. When sparse requirements expose a metadata aspect, bind it through an opaque bind using `VK_SPARSE_MEMORY_BIND_METADATA_BIT` before the image is used.
+
+Tail and metadata requirements are implementation-defined. Never infer them solely from texture dimensions.
+
+### 6.4 Physical sparse memory pools
+
+Do not allocate one `VkDeviceMemory` object per page. Allocate large device-local chunks for each compatible memory type and suballocate aligned sparse blocks.
+
+A sparse pool tracks:
+
+- memory type and heap;
+- allocation chunks;
+- allocation alignment and block size;
+- free blocks or ranges;
+- page owner and generation;
+- pending bind/unbind state;
+- and deferred reclamation after GPU completion.
+
+For non-tail image blocks, physical-byte accounting is the number of bound blocks multiplied by the required aligned block allocation. Add tail and metadata allocations separately.
+
+### 6.5 Bind, upload, and publication ordering
+
+Sparse memory binding uses `vkQueueBindSparse`; it is not a command-buffer operation and is not implicitly ordered with transfer, graphics, or compute submissions.
+
+Promotion follows this dependency chain:
+
+```text
+Reserve physical blocks
+→ submit vkQueueBindSparse
+→ signal bind-complete semaphore/timeline value
+→ transfer or graphics submission waits for bind completion
+→ transition/copy the page data
+→ signal upload-complete timeline value
+→ verify texture/cache generation
+→ publish image-view LOD state or virtual page-table mapping
+```
+
+Binary or timeline semaphores may be used as supported by the submission path. The dependency must remain explicit even when sparse bind and copy execute on the same queue.
+
+### 6.6 Eviction and unbind ordering
+
+Eviction follows:
+
+```text
+Publish a valid ancestor/fallback mapping
+→ retire every frame that can observe the old mapping
+→ submit vkQueueBindSparse with VK_NULL_HANDLE memory for the old region
+→ wait for unbind completion
+→ return blocks to the sparse pool
+```
+
+Returning memory to the pool before the old mapping and submissions retire can cause previous frames to observe unrelated data that reused the same block.
+
+### 6.7 Image-layout strategy
+
+Sparse binding does not perform image layout transitions. Vulkan image layouts and barriers operate on image subresources such as aspect, mip, and array layer; they do not transition one rectangular sparse tile independently inside a mip.
+
+For a direct sparse logical image with concurrent sampling and page uploads in the same mip, the practical choices are:
+
+1. keep streamed subresources in `VK_IMAGE_LAYOUT_GENERAL` and use explicit transfer-write-to-shader-read dependencies; or
+2. use a software SVT physical cache where each tile occupies a separate 2D-array layer, allowing per-layer transitions and copies.
+
+The second option is the recommended portable production baseline. Direct sparse logical images remain an optional advanced backend after cross-vendor validation.
+
+### 6.8 Descriptor publication
+
+Dense Vulkan streaming may replace the underlying image/view and therefore requires descriptor publication after upload completion.
+
+A direct sparse image can retain a stable image descriptor. Its publication boundary is instead the page table, resident LOD clamp, or another shader-visible residency structure. That structure still cannot be updated until sparse bind and upload completion are proven.
+
+### 6.9 Nonresident sampling
+
+`residencyNonResidentStrict` determines whether nonresident reads have strict zero behavior. Without it, read values are undefined, though memory safety is preserved. Correct rendering must not depend on either behavior.
+
+Use a page-table ancestor fallback or prevent sampling of unbound direct-sparse regions.
+
+## 7. Portable Streaming Virtual Texture Architecture
+
+### 7.1 Why software indirection is the baseline
+
+A software-indirected SVT provides the same asset and shader contract on OpenGL and Vulkan, works when sparse resources are unsupported, provides deterministic missing-page fallback, and decouples engine page geometry from hardware page geometry.
+
+The first production implementation should use dense physical cache banks. Hardware sparse memory can later back cache banks or selected direct images without changing logical page identifiers or cooked assets.
+
+### 7.2 Proposed runtime owners
+
+Keep the current mip streamer and add a separate subsystem rather than overloading `ITextureResidencyBackend`:
+
+- `VirtualTextureManager` — frame-level orchestration and budgets.
+- `VirtualTextureRegistry` — logical assets, users, material sets, and generations.
+- `VirtualTextureFeedbackResolver` — request deduplication, weighting, guard bands, and prefetch.
+- `VirtualTexturePageStreamer` — page I/O, decode/transcode, cancellation, and upload scheduling.
+- `VirtualTexturePhysicalCache` — per-format cache banks, slot ownership, eviction, and deferred reuse.
+- `VirtualTexturePageTable` — CPU shadow, GPU representation, versioning, and publication.
+- `IVirtualTexturePageBackend` — API-specific page upload and page-table publication.
+
+`ImportedTextureStreamingManager` remains responsible for ordinary imported-texture preview and whole-mip residency. It also provides the fallback path for assets that are not virtualized.
+
+### 7.3 Logical page identity
+
+A logical page identifier contains at least:
+
+```text
+texture id
+material-set or layer id
+mip level
+page x
+page y
+source/cook generation
+```
+
+Requests are discrete page IDs, not one normalized UV rectangle. This permits disjoint visible regions, many instances, multiple materials, multiple views, and independent page priorities.
+
+For material texture sets, page identity should support synchronized bundles such as base color, normal, and scalar channels. The policy may stream them as one logical material page to avoid mismatched detail across channels.
+
+### 7.4 Logical tiles versus hardware pages
+
+The cooked asset defines a stable logical interior tile size and stored border size. A backend maps that logical tile to its physical representation:
+
+- one logical tile per dense array layer;
+- one logical tile spanning multiple OpenGL or Vulkan sparse blocks;
+- multiple logical tiles packed into a compatible larger allocation;
+- or dense mip fallback when hardware geometry is unsuitable.
+
+Never encode `GL_VIRTUAL_PAGE_SIZE_INDEX_ARB`, OpenGL page dimensions, Vulkan sparse granularity, queue families, or device memory offsets into the portable logical page contract.
+
+### 7.5 Cooked page-addressable payload
+
+The virtual-texture payload includes:
+
+- logical texture dimensions and mip count;
+- logical interior tile width and height;
+- stored width and height including borders;
+- border size and generation policy;
+- format, color space, and texture role;
+- wrap mode used to generate borders;
+- page mip/X/Y/layer identity;
+- per-page byte offset and byte length;
+- compressed block geometry and row/slice metadata where applicable;
+- content checksum or hash;
+- source and cooker versions;
+- fallback mip descriptors;
+- and optional page-group metadata for material bundles.
+
+Borders are generated before GPU-native compression so runtime upload remains copy-only. Stored extents and offsets must satisfy the compression format's block alignment.
+
+### 7.6 Dense physical cache banks
+
+The recommended first backend uses 2D-array texture banks:
+
+- one array layer per tile slot;
+- multiple banks when layer limits are reached;
+- fixed dimensions including borders;
+- exact memory accounting;
+- per-format or per-role pools;
+- and no dependency on hardware sparse-resource support.
+
+Initial format banks should include, as platform support permits:
+
+- BC7 or equivalent sRGB/linear color banks;
+- BC5 normal banks;
+- BC4 scalar banks;
+- RGBA8 portable fallback banks.
+
+A cache slot records its owner page, generation, last use, priority, pin state, and the frame/page-table version after which it may be reused.
+
+### 7.7 Virtual page table
+
+A page-table entry encodes at least:
+
+- valid/resident bit;
+- physical cache bank;
+- physical slot or array layer;
+- resolved resident mip;
+- fallback/ancestor mip delta;
+- mapping generation;
+- and optional format/material-set flags.
+
+The table may be stored in integer textures, texture buffers, or storage buffers according to backend capability and lookup cost. Its public logical layout must be shared across OpenGL and Vulkan shader implementations.
+
+Use double- or triple-buffered page-table publication, or an equivalent versioned scheme, so mappings consumed by in-flight frames are immutable. Cache slots referenced by an old table version remain unavailable for reuse until that version retires.
+
+### 7.8 Page lifecycle
+
+Promotion uses the following state machine:
+
+```text
+Requested
+→ IoQueued
+→ PayloadReady
+→ CacheSlotReserved
+→ UploadSubmitted
+→ GpuComplete
+→ MappingPublished
+→ Resident
+```
+
+Eviction uses:
+
+```text
+Resident
+→ AncestorMappingPublished
+→ OldTableVersionsRetired
+→ OptionalSparseUnbindComplete
+→ CacheSlotReleased
+→ Evicted
+```
+
+Failures at any stage retain or restore a valid ancestor mapping. A partially uploaded slot is never published.
+
+### 7.9 Feedback generation
+
+The first feedback path should be GPU-generated and asynchronously resolved. Viable implementations include:
+
+- a reduced-resolution integer feedback target written during material sampling;
+- a storage-buffer hash or bitset updated with atomics;
+- or a dedicated material resolve pass that emits page IDs.
+
+The feedback record should include or permit reconstruction of:
+
+- logical page ID;
+- requested mip;
+- sample count or screen coverage;
+- view/eye/foveation priority;
+- and optional material role.
+
+A compute resolve pass deduplicates requests, aggregates importance, expands guard bands, and compacts a bounded request list. CPU readback uses a persistently mapped or staged ring with one or more frames of latency and no render-thread wait.
+
+### 7.10 Request resolution and prediction
+
+The resolver applies:
+
+- fallback-aware deduplication;
+- screen-error or requested-mip weighting;
+- page neighborhood expansion for filtering;
+- camera and head angular/linear velocity prediction;
+- short residency TTLs and hysteresis;
+- starvation prevention across assets;
+- and global physical-cache and upload budgets.
+
+A camera teleport or invalid shader-generated UV domain should temporarily request a coarser complete fallback rather than flooding the streamer with unbounded pages.
+
+### 7.11 Filtering and borders
+
+Hardware filtering cannot cross unrelated physical cache slots. The virtual sampling helper must:
+
+1. compute LOD from derivatives of the original virtual UVs;
+2. resolve the requested page or a resident ancestor;
+3. remap UVs into the physical tile interior;
+4. sample with border texels for bilinear continuity;
+5. resolve the adjacent virtual mip for trilinear filtering;
+6. sample its independently resolved page/ancestor;
+7. blend the two mip results.
+
+The border must cover the supported filtering footprint. Initial anisotropy should be capped to what the configured border safely supports. Higher anisotropy can use wider borders, additional taps, or a more advanced page neighborhood scheme.
+
+Borders must honor authored wrap behavior:
+
+- repeat borders wrap to the opposite logical edge;
+- mirror borders mirror the source neighborhood;
+- clamp borders duplicate edge texels;
+- and unsupported procedural or shader-generated addressing opts out or uses a conservative fallback.
+
+### 7.12 VR and foveated views
+
+Physical residency is shared across views. Feedback carries view identity and priority, but identical logical page requests from both eyes are unioned before streaming.
+
+Recommended priority order:
+
+```text
+HMD foveal samples
+> HMD peripheral samples
+> gameplay-critical auxiliary views
+> desktop mirror
+> reflections, probes, and background captures
+```
+
+The resolver chooses the finest page required by any important view and retains one shared physical copy. Stereo divergence, head rotation, and foveation movement expand prefetch neighborhoods rather than creating per-eye duplicate caches.
+
+## 8. Integration With Existing XRENGINE Streaming
+
+### 8.1 Keep the existing mip contract intact
+
+`ITextureResidencyBackend` is intentionally mip-oriented: it accepts resident dimensions, mip arrays, sparse mip metadata, and one coarse page-selection hint. It should not be expanded into a general SVT page API.
+
+Add an independent page-batch backend, conceptually:
+
+```csharp
+internal interface IVirtualTexturePageBackend
+{
+    VirtualTextureCapabilities Capabilities { get; }
+
+    PageUploadTicket EnqueuePageUploads(
+        ReadOnlySpan<VirtualTexturePageUpload> uploads,
+        long cacheGeneration);
+
+    PageTablePublishTicket PublishMappings(
+        ReadOnlySpan<VirtualTexturePageMapping> mappings,
+        long tableGeneration);
+
+    void RevokeMappings(
+        ReadOnlySpan<VirtualPageId> pages,
+        long tableGeneration);
+
+    bool IsComplete(PageUploadTicket ticket);
+}
+```
+
+The exact public types can change during implementation. The invariant is that the interface operates on logical page batches and completion tickets without leaking API-native objects.
+
+### 8.2 OpenGL backend strategy
+
+Implement in this order:
+
+1. dense 2D-array cache banks and integer page table;
+2. asynchronous PBO/shared-context tile uploads with fence-gated mapping publication;
+3. optional hardware-sparse backing for very large cache banks;
+4. optional direct sparse logical-image experiments only after robust residency-aware fallback and cross-vendor testing.
+
+The current sparse whole-mip backend remains the fallback for nonvirtualized large textures.
+
+### 8.3 Vulkan backend strategy
+
+Implement in this order:
+
+1. dense 2D-array cache banks integrated with the existing staging, transfer, timeline, and publication service;
+2. per-layer layout transitions and copies;
+3. timeline-gated page-table publication and frame-safe slot retirement;
+4. hardware sparse image capability probing and memory pools;
+5. optional sparse backing for cache banks or selected direct images.
+
+Reuse the current Vulkan generation ledger, worker preparation, bounded transfer batching, descriptor/publication authority, and deferred resource retirement patterns rather than creating a parallel unbounded uploader.
+
+## 9. Validation Requirements
+
+### 9.1 OpenGL sparse mip validation
+
+- base `GL_ARB_sparse_texture` page-aligned allocation;
+- sparse-texture2 nonaligned base dimensions;
+- every selected page-layout index used by policy;
+- mip-tail atomic commitment and uncommit;
+- edge commitment rectangles;
+- promotion upload before base-level exposure;
+- demotion exposure before uncommit;
+- shared-context fence completion;
+- stale storage-generation cancellation;
+- exact-format compressed sparse fallback;
+- `KHR_debug` clean runs on supported vendors;
+- dense fallback on unsupported target/format pairs.
+
+### 9.2 Vulkan dense streaming validation
+
+- cold- and warm-cache imported scenes;
+- generation cancellation and descriptor publication ordering;
+- bounded worker, transfer, completion, and retirement work;
+- exact frame readiness behavior for visible textures;
+- low-memory retries;
+- device-loss cancellation and cleanup;
+- validation-layer clean runs.
+
+### 9.3 Vulkan sparse validation
+
+- dedicated and combined sparse queue families;
+- exact-format property rejection and fallback;
+- non-tail image block binds;
+- single and per-layer mip tails;
+- metadata aspect binding when reported;
+- bind-before-copy semaphore ordering;
+- upload-before-mapping publication;
+- fallback-before-unbind ordering;
+- exact bound-byte accounting;
+- cancellation while bind or copy work is in flight;
+- device loss with outstanding sparse ownership.
+
+### 9.4 SVT validation
+
+- bilinear and trilinear continuity at page boundaries;
+- repeat, mirror, and clamp border correctness;
+- compressed page block alignment;
+- oblique surfaces and anisotropic filtering limits;
+- high-speed camera movement and camera teleport;
+- dual-eye page divergence and union;
+- foveation priority changes;
+- cache exhaustion, eviction, and slot-generation reuse;
+- old page-table versions referencing retired slots;
+- stale I/O and upload cancellation;
+- missing-page ancestor stability;
+- feedback overflow and bounded compaction;
+- no synchronous render-thread feedback readback;
+- exact dense-cache memory accounting.
+
+## 10. Implementation Order
+
+1. Close validation of current OpenGL and Vulkan mip streaming.
+2. Correct capability terminology and backend telemetry.
+3. Add page-addressable cooked texture payloads and fallback mips.
+4. Add dense per-format physical cache banks on both APIs.
+5. Add a versioned virtual page table and manual page requests.
+6. Add shader sampling helpers with borders and ancestor fallback.
+7. Add GPU feedback, asynchronous resolve/readback, and prediction.
+8. Validate stereo/foveated behavior and cache pressure.
+9. Add Vulkan hardware sparse residency as an optional backend.
+10. Evaluate OpenGL/Vulkan sparse backing for physical caches.
+11. Add RVT producers after SVT ownership and publication are stable.
+
+This order produces a portable, deterministic system first and treats hardware sparse residency as an optimization rather than a prerequisite.

--- a/docs/work/design/texturing/texture-runtime-streaming-virtual-texturing-design.md
+++ b/docs/work/design/texturing/texture-runtime-streaming-virtual-texturing-design.md
@@ -1,8 +1,8 @@
 # Texture Runtime, Streaming, And Virtual Texturing Design
 
-Last Updated: 2026-05-19
+Last Updated: 2026-09-02
 Status: canonical work design
-Scope: imported texture streaming, cooked texture cache payloads, sparse residency, upload scheduling, virtual texturing roadmap, bindless deferred texturing integration, and neural compression integration.
+Scope: imported texture streaming, cooked texture cache payloads, dense and sparse residency, upload scheduling, streaming virtual texturing, runtime virtual texturing, bindless deferred texturing integration, and neural compression integration.
 
 Supersedes:
 
@@ -20,6 +20,7 @@ Execution tracker:
 
 Companion designs:
 
+- [Sparse Residency And Streaming Virtual Texturing Backend Guide](sparse-residency-and-svt-backend-guide.md)
 - [Texture Compression And Cooked Texture Cache Design](texture-compression-and-cooked-cache-design.md)
 
 Companion trackers:
@@ -28,118 +29,198 @@ Companion trackers:
 
 ## Summary
 
-XRENGINE now has a working v1 texture runtime: imported textures are registered with a streaming manager, source data can come from metadata-first cooked cache assets, uploads are budgeted and generation-gated, and OpenGL can use sparse texture mip residency when the hardware and texture dimensions allow it.
+XRENGINE has a working v1 texture runtime. Imported textures register with a streaming manager, metadata-first cooked cache assets can provide selected mip ranges, uploads are budgeted and generation-gated, OpenGL can use hardware sparse whole-mip residency, and Vulkan has a dense synchronized upload path with worker preparation, transfer submission, GPU-completion-gated descriptor publication, and deferred retirement.
 
-That implementation is not full virtual texturing yet. The active sparse path can avoid committing the full logical mip chain, but it does not have GPU page feedback, a physical tile cache, page-table sampling, UDIM-scale page indirection, or runtime virtual texture generation. This document treats the existing implementation as the v1 foundation and defines the next architecture steps toward streaming virtual textures, bindless material resolve, Vulkan parity, and optional neural compression.
+That implementation is not full virtual texturing. The active paths stream mip ranges, not arbitrary logical texture pages selected by GPU feedback. XRENGINE does not yet have a page-addressable cooked payload, shared physical tile cache, virtual page table, shader-side page-table sampling, page feedback and resolve, UDIM-scale indirection, or runtime-generated virtual texture pages.
+
+The production cross-API SVT target is a software-indirected system built around dense physical tile cache banks and a versioned page table. Hardware sparse resources are optional backend optimizations. They must not define the portable asset format, logical page size, page identity, shader contract, or correctness fallback.
+
+Normative API details and call ordering live in the [Sparse Residency And Streaming Virtual Texturing Backend Guide](sparse-residency-and-svt-backend-guide.md).
+
+## Terminology And Feature Tiers
+
+These terms are not interchangeable:
+
+- **Dense mip streaming:** create or publish an ordinary fully backed texture containing a selected resident mip range.
+- **Hardware sparse mip residency:** keep one stable logical image while physically committing selected complete mips.
+- **Hardware sparse page residency:** commit device-defined regions inside independently sparse-manageable mips.
+- **Streaming virtual texturing (SVT):** map engine-defined logical pages through a virtual page table into a shared physical tile cache, driven by sampling feedback and backed by page-addressable cooked data.
+- **Runtime virtual texturing (RVT):** use the same virtual-page infrastructure, but render or generate page contents at runtime rather than reading cooked page blobs.
+
+Sparse residency is a memory-binding mechanism. It does not by itself provide the asset addressing, physical tile reuse, filtering borders, page-table fallback, feedback, or eviction policy required by SVT.
+
+## Current Backend Capability Matrix
+
+| Capability | OpenGL | Vulkan |
+|---|---:|---:|
+| Dense/tiered mip streaming | Implemented | Implemented |
+| Generation-gated asynchronous preparation | Implemented | Implemented |
+| GPU-completion-gated publication | Implemented for shared-context sparse promotion | Implemented for dense image/descriptor publication |
+| Hardware sparse whole-mip residency | Implemented for eligible imported `XRTexture2D` assets | Not implemented |
+| Hardware sparse partial-page residency | Scaffolded; disabled by policy | Not implemented |
+| Page-addressable cooked payload | Not implemented | Not implemented |
+| Shared physical tile cache | Not implemented | Not implemented |
+| Virtual page table | Not implemented | Not implemented |
+| GPU page feedback and resolve | Not implemented | Not implemented |
+| Full SVT | Not implemented | Not implemented |
+| RVT page production | Not implemented | Not implemented |
 
 ## Current Implementation Snapshot
 
-The current runtime is split into focused services:
+The renderer-neutral runtime is split into focused services:
 
-- `ImportedTextureStreamingManager` is the frame-level coordinator. It collects snapshots, asks policy for desired residency, queues transitions, finalizes sparse exposure, publishes telemetry, and emits summaries.
+- `ImportedTextureStreamingManager` is the frame-level coordinator. It collects snapshots, asks policy for desired residency, queues transitions, finalizes safe publication, publishes telemetry, and emits summaries.
 - `TextureStreamingRegistry` owns weak texture records, main-view usage recording, material binding observations, compaction, and immutable snapshots.
-- `TextureResidencyPolicy` owns deterministic decisions: desired resident size, budget fitting, role multipliers, priority scoring, fairness groups, transition reason text, promotion fade, and sparse page selection.
+- `TextureResidencyPolicy` owns deterministic desired-residency decisions, budget fitting, role multipliers, priority scoring, fairness, transition reasons, promotion fade, and the current coarse sparse-page-selection hint.
 - `TextureTransitionQueue` owns pending transition replacement, stale transition repair, lifecycle timestamps, cancellation, and pending-state reset.
 - `TextureUploadScheduler` owns progressive upload queueing, priority ordering, duplicate coalescing, active-slot gates, frame budgets, generation cancellation, and queue-wait telemetry.
-- `TextureResidencyState` centralizes mutable sparse/dense residency fields on `XRTexture2D` while public properties keep `SetField(...)` mutation semantics.
-- `GLTieredTextureResidencyBackend` is the compatibility backend. It swaps resident mip chains or resident dimensions.
-- `GLSparseTextureResidencyBackend` is the preferred OpenGL backend for eligible imported `XRTexture2D` assets. It allocates logical sparse texture storage and commits only the resident mip range.
+- `TextureResidencyState` centralizes mutable residency fields on `XRTexture2D` while public properties keep `SetField(...)` mutation semantics.
+
+OpenGL backends:
+
+- `GLTieredTextureResidencyBackend` is the dense compatibility backend. It swaps resident mip chains or resident dimensions.
+- `GLSparseTextureResidencyBackend` is the preferred OpenGL backend for eligible imported textures. It allocates full logical sparse storage and commits only the required mip range.
+- Shared-context sparse promotions upload and commit on a secondary context, insert a fence, and publish the finer sampling range only after render-thread fence completion and storage-generation validation.
+
+Vulkan backends and services:
+
+- `VulkanDenseTextureResidencyBackend` implements dense imported-texture residency and uses the same renderer-neutral policy inputs.
+- `VulkanTextureUploadService` owns worker preparation, bounded staging and transfer work, generation tracking, transfer completion, descriptor publication, and retirement.
+- `VulkanTextureStreamingBackendProvider` currently routes both default and nominal sparse requests to the dense backend.
+- `VulkanSparseTextureStreamingService` explicitly reports true sparse image residency as unsupported and provides only dense compatibility behavior.
 
 The active source path is:
 
 - First import may decode the original source file.
-- Fresh cache paths prefer `AssetTextureStreamingSource`.
+- Fresh cooked cache paths prefer `AssetTextureStreamingSource`.
 - Stale, missing, or unusable cache entries fall back to `ThirdPartyTextureStreamingSource`.
 - A short-lived resident-data reuse cache lets superseded transitions reuse compatible prepared mip data.
-- Cooked cache usability is metadata-first and no longer requires hydrating resident mips just to decide whether an asset is streamable.
+- Cooked cache usability is metadata-first and no longer requires hydrating resident mip blobs merely to decide whether an asset is streamable.
 
-## Current Sparse Residency Reality
+## Current OpenGL Sparse Residency Reality
 
-OpenGL sparse support is implemented around `GL_ARB_sparse_texture`:
+OpenGL sparse support is implemented around `GL_ARB_sparse_texture` and detects `GL_ARB_sparse_texture2`:
 
-- Renderer init probes `GL_ARB_sparse_texture` and `GL_ARB_sparse_texture2`.
-- It queries `GL_VIRTUAL_PAGE_SIZE_X_ARB` and `GL_VIRTUAL_PAGE_SIZE_Y_ARB` for `Rgba8`.
-- Textures whose logical dimensions are not page-aligned use the tiered fallback.
-- Sparse storage is created by setting `GL_TEXTURE_SPARSE_ARB = GL_TRUE` before `glTextureStorage2D`.
-- The backend queries `GL_NUM_SPARSE_LEVELS_ARB` and treats the mip tail as an atomic commitment region.
-- Promotions commit and upload new mips before lowering `GL_TEXTURE_BASE_LEVEL`.
-- Demotions expose the lower-detail range before uncommitting inaccessible high-detail mips.
-- Shared-context sparse promotions are fence-gated. The render thread only exposes newly uploaded mips after the fence signals.
-- VRAM accounting uses committed bytes, not the logical full texture size.
+- Renderer initialization probes both extensions.
+- It queries the number of virtual page layouts and X/Y page dimensions for `Rgba8`.
+- The current implementation chooses the first usable page-size layout.
+- Sparse storage is created by setting `GL_TEXTURE_SPARSE_ARB = GL_TRUE` and `GL_VIRTUAL_PAGE_SIZE_INDEX_ARB` before `glTextureStorage2D`.
+- The backend queries `GL_NUM_SPARSE_LEVELS_ARB` and treats the mip tail as one atomic commitment region.
+- Promotions commit and upload new data before lowering `GL_TEXTURE_BASE_LEVEL`.
+- Demotions populate and expose the lower-detail range before uncommitting inaccessible high-detail mips.
+- Shared-context sparse promotions are fence-gated.
+- VRAM accounting uses an estimate of committed bytes rather than the full logical texture size.
 
-Partial sparse page machinery exists, but it is not active by default. The code has:
+The current implementation conservatively requires the logical base dimensions to be page-aligned even when `GL_ARB_sparse_texture2` is available. Base sparse textures require the applicable alignment restrictions. Sparse-texture2 permits arbitrary base dimensions while individual commitment rectangles must still obey page-origin and mip-edge rules. Relaxing the current gate is future implementation work and requires edge-commit validation.
 
-- `SparseTextureStreamingPageSelection`
-- `SparseTextureStreamingPageRegion`
-- UV-bounds-derived page selection in `RenderableMesh`
-- partial region commit/uncommit helpers in `GLTexture2D.SparseStreaming.cs`
-- byte estimation for partial sparse regions
-- texture-streaming telemetry fields for current and desired page coverage
+Partial sparse page machinery exists, including:
 
-The current policy intentionally returns full page coverage because `EnablePartialSparsePageResidency` is `false`. The previous UV-bounds-only approach is too coarse for default use: it does not account for material UV transforms, wrap modes, anisotropic/filter guard bands, shader-generated UVs, virtual-geometry visibility, or rapid camera movement. Until page requests are driven by actual sampling domains or feedback, page-level sparse residency must remain opt-in or disabled.
+- `SparseTextureStreamingPageSelection`;
+- `SparseTextureStreamingPageRegion`;
+- UV-bounds-derived page selection in `RenderableMesh`;
+- partial region commit, uncommit, and upload helpers;
+- byte estimation for partial sparse regions;
+- telemetry fields for current and desired page coverage.
+
+Policy intentionally returns full coverage because `EnablePartialSparsePageResidency` is disabled. One normalized UV rectangle is not a reliable sampling domain. It does not fully account for material UV transforms, wrap modes, anisotropic and filtering guard bands, normal or parallax perturbation, shader-generated UVs, disjoint visible islands, virtual geometry visibility, multiple instances, stereo divergence, or rapid camera motion.
+
+Direct partial commitment should remain an optional bridge or diagnostic feature. It is not a prerequisite for portable SVT.
+
+## Current Vulkan Dense Streaming Reality
+
+Vulkan imported-texture streaming is not merely placeholder work. The dense path already provides:
+
+- bounded asynchronous decode and cache reads;
+- generation-gated acceptance and cancellation;
+- worker-owned native preparation;
+- bounded staging allocation and upload chunking;
+- transfer or graphics queue submission;
+- GPU completion polling without device-wide idle;
+- descriptor publication only after completion and authority acquisition;
+- exact-once callback handling;
+- deferred staging and old-resource retirement;
+- upload, queue, publication, and failure telemetry.
+
+The remaining Vulkan v1 work is validation and render-tail closure, not basic backend creation.
+
+True Vulkan sparse image residency is still absent. There is no sparse image capability probe, sparse queue selection, sparse block pool, mip-tail or metadata binding, `vkQueueBindSparse` dependency chain, partial sparse image upload path, or sparse unbind and reclamation path.
 
 ## What This Is Not Yet
 
-The current runtime is not a full SVT/MegaTexture system.
+The current runtime is not a full SVT/MegaTexture system. Missing pieces include:
 
-Missing pieces:
+- page-addressable cooked texture blobs;
+- stable logical virtual page identifiers;
+- GPU-generated page feedback;
+- per-frame request deduplication and prioritization;
+- a globally budgeted physical tile cache;
+- a versioned virtual page table;
+- shader-side page-table lookup and ancestor fallback;
+- filtering borders and virtual trilinear sampling;
+- frame-safe cache-slot reuse;
+- UDIM/material-set page indirection;
+- shared stereo/foveated page resolution;
+- runtime page producers for terrain, decals, splines, or procedural materials.
 
-- GPU-driven texture-page feedback.
-- Per-frame page request resolve.
-- A physical tile cache shared across many logical textures.
-- Shader-side virtual page table lookup.
-- Page-addressable cooked texture blobs.
-- UDIM/material-set page indirection.
-- Per-eye page residency for VR.
-- Runtime virtual textures generated from terrain, decals, splines, or procedural materials.
+The current runtime is also not bindless deferred texturing yet. `GPUMaterialTable` and descriptor-indexing groundwork exist elsewhere, but normal render paths still materialize material properties in the usual geometry and forward paths.
 
-The current runtime is also not bindless deferred texturing yet. `GPUMaterialTable` and descriptor-indexing groundwork exist elsewhere, but the classic geometry pass still materializes material properties in the usual render paths.
-
-Neural texture compression is still a future asset-pipeline feature. It should not be wired into material shaders until the cooked asset contract, validation metrics, and fallback paths exist.
+Neural texture compression remains a future asset-pipeline feature. It should not be added to material shaders until the cooked asset contract, quality metrics, backend capability contract, and conventional fallback paths exist.
 
 ## Design Invariants
 
-### Stable Material Texture Identity
+### Stable Material And Virtual Texture Identity
 
-Materials should keep stable `XRTexture` references. Streaming may change resident mips, committed sparse pages, internal GL storage, or backend state, but material slots should not churn object references unless the asset itself changes.
+Materials retain stable `XRTexture` or virtual-texture references. Streaming may change resident mips, committed hardware pages, backing image storage, cache slots, descriptors, or page-table mappings, but material slots must not churn logical references unless the asset itself changes.
 
 ### Sampling Safety
 
-Sampling must never reach missing or uncommitted data.
+Sampling must never intentionally reach incomplete or unmapped data.
 
-- Progressive uploads hide partially uploaded mips.
-- Sparse textures clamp `GL_TEXTURE_BASE_LEVEL` and `GL_TEXTURE_MAX_LEVEL` to exposed resident data.
-- Sparse promotion lowers the base level only after commit, upload, and fence completion.
-- Sparse demotion must make the target lower-detail range valid before high-detail uncommit.
+- Progressive dense uploads hide incomplete images or mip ranges.
+- Sparse whole-mip textures clamp the sampling range to exposed resident data.
+- OpenGL sparse promotion lowers the base level only after commit, upload, fence completion, and generation validation.
+- Vulkan dense publication swaps descriptors only after transfer completion.
+- SVT publishes a page-table entry only after its physical tile upload completes.
+- Missing SVT pages resolve to valid resident ancestors, never to an uninitialized slot.
+
+Correctness must not depend on the value returned by a nonresident OpenGL or Vulkan sparse read.
+
+### Revoke Before Reuse
+
+A cache slot or sparse memory block cannot be reused until all shader-visible references to the old owner have been replaced and all frames that may observe the old mapping have retired. Vulkan sparse memory additionally requires unbind completion before reuse.
 
 ### Generation-Gated GPU Work
 
-Every queued upload or sparse transition captures the texture storage generation it was prepared against. If storage is resized, recreated, deleted, replaced by external memory, or switched between sparse and dense storage, stale work must cancel or restart.
+Every queued read, decode, transcode, upload, sparse bind, page-table update, and publication captures relevant texture, storage, cache, source, and mapping generations. If ownership changes, stale work cancels or becomes nonpublishable.
 
 ### Renderer-Neutral Policy
 
-Policy code should not know GL handles, Vulkan image layouts, or backend-specific sparse flags. It should speak in logical dimensions, resident size, base mip, page selection, estimated committed bytes, priority, deadline class, and telemetry.
+Policy code must not know GL handles, Vulkan images, image layouts, queue families, memory offsets, or extension enums. It speaks in logical dimensions, mip quality, virtual page IDs, desired page sets, estimated or exact bytes, priority, deadline class, source version, generation, and completion state.
+
+### Logical Tiles Are Not Hardware Pages
+
+The cooked asset defines an engine logical tile interior and stored border. A backend maps those tiles to dense array layers or one or more hardware sparse pages. OpenGL page-layout indices and Vulkan sparse image granularity never become the portable logical tile contract.
 
 ### Metadata-First Source Loading
 
-Runtime streaming must inspect compact cache metadata before reading texture blobs. Full YAML hydration, raw source decode, or full mip-chain reads are fallback paths, not the warm-cache steady state.
+Runtime streaming inspects compact cache metadata before reading blobs. Full YAML hydration, source image decode, or full mip-chain reads are fallback paths rather than the warm-cache steady state.
 
 ### Hot-Path Allocation Discipline
 
-Per-frame visibility, scoring, upload submission, and render-thread upload code are hot paths. They must avoid LINQ, captured closures, boxing, string construction, and transient heap allocations after warmup unless profiling proves the cost is harmless.
+Per-frame visibility, feedback resolution, scoring, transition queueing, upload submission, page-table updates, and render-thread publication must avoid LINQ, captured closures, boxing, string construction, and transient heap allocations after warmup unless profiling proves them harmless.
 
-## Runtime Flow
+## Current Mip Streaming Flow
 
 1. Imported materials register texture assets with `ImportedTextureStreamingManager`.
-2. The registry tracks source path, texture role, backend, current residency, pending transitions, and last usage.
+2. The registry tracks source path, texture role, backend, current residency, pending transitions, and last use.
 3. Main non-shadow passes record visible usage through `ImportedTextureStreamingUsage`.
-4. Policy computes desired resident size and page selection from projected pixel span, screen coverage, distance, UV density, sampler role, recency, fairness, and VRAM pressure.
+4. Policy computes desired resident quality from projected pixel span, screen coverage, distance, UV density, sampler role, recency, fairness, and memory pressure.
 5. The transition queue coalesces identical work and cancels superseded work.
-6. The source layer loads the selected mip range from cooked cache where possible.
+6. The source layer loads the selected mip range from the cooked cache when possible.
 7. The backend applies the transition:
-   - tiered backend uploads a resident mip chain into dense storage
-   - sparse backend commits sparse pages/mips, uploads data, and exposes sampling only after safe completion
-8. Telemetry and logs report desired residency, queue wait, upload timing, committed bytes, validation failures, binding risk, fallback use, and VRAM summaries.
+   - OpenGL or Vulkan dense backends create and publish a dense resident mip chain;
+   - the OpenGL sparse backend commits sparse mips/pages, uploads data, and publishes the finer sampling range only after safe completion.
+8. Telemetry reports desired residency, queue wait, upload timing, estimated or exact bytes, validation failures, binding risk, fallback use, and memory summaries.
 
 ## Cooked Texture Cache
 
@@ -147,193 +228,299 @@ The implemented cooked payload uses the streamable mip section in `XRTexture2D.S
 
 Current properties:
 
-- Magic: `0x58525453` (`XRTS`)
-- Per-mip descriptors with width, height, format, byte offset, and byte length
-- Explicit preview base mip index
-- Selected mip-range reads
-- Metadata-first streamability checks
-- Uncompressed `Rgba8` mip blobs as the first portable format
+- Magic: `0x58525453` (`XRTS`).
+- Per-mip descriptors with width, height, format, byte offset, and byte length.
+- Explicit preview base mip index.
+- Selected mip-range reads.
+- Metadata-first streamability checks.
+- Uncompressed `Rgba8` mip blobs as the first portable format.
 
 Current limitations:
 
-- Color-space metadata is still incomplete.
-- Texture role metadata is not complete enough for all policy and compression decisions.
+- Color-space metadata is incomplete.
+- Texture-role metadata is not complete enough for every policy and compression decision.
 - The payload is mip-addressable, not page-addressable.
-- BCn payloads are future work and must be gated by dependency/license review plus backend capability checks.
-- Sparse compressed page commitment requires `GL_ARB_sparse_texture2`, which has narrower hardware coverage than base sparse textures.
+- GPU-native BCn payloads and compressed uploads are not implemented.
+- It does not distinguish logical tile interior dimensions from stored dimensions including borders.
+
+Sparse compressed-format support must be queried for the exact target and internal format. Base `GL_ARB_sparse_texture` may expose compressed sparse layouts; `GL_ARB_sparse_texture2` does not make compressed sparse formats universally supported. Dense BCn physical cache banks remain the portable SVT strategy even when direct sparse BCn is unavailable.
 
 Target upgrades:
 
-- Add color space and texture role to the manifest.
-- Add optional page descriptors for page-addressable SVT.
-- Add BC7/BC5/BC4 payload variants where platform support and license review allow.
-- Keep an `Rgba8` fallback for sparse paths that only support `GL_ARB_sparse_texture`.
-- Make cache logs distinguish file I/O, manifest parse, blob copy, CPU conversion, and GPU upload time.
+- Add complete color space and texture role metadata.
+- Add page-addressable descriptors with logical page identity, per-page offsets and lengths, format/block metadata, checksum, and source/cook generation.
+- Define logical interior tile dimensions separately from stored dimensions including borders.
+- Generate wrap-aware borders before GPU-native compression.
+- Add BC7, BC5, and BC4 payload variants where platform support and dependency/license review allow.
+- Keep a portable uncompressed fallback where required.
+- Make cache logs distinguish file I/O, manifest parsing, blob copying, CPU conversion, GPU upload, and publication time.
 
 ## Full Streaming Virtual Textures
 
-SVT is the natural next major step after sparse mip residency.
+SVT is the next major architecture step after v1 mip streaming is validated.
 
-Target architecture:
+### Logical asset
 
-- A logical virtual texture owns source dimensions, mip count, format, tile size, and a stable texture asset identity.
-- A physical tile cache owns resident GPU memory. It is budgeted globally and reused across many virtual textures.
-- A page table maps `(texture id, mip, tile x, tile y)` to physical cache coordinates or fallback pages.
-- A feedback pass records visible page requests from actual screen-space sampling demand.
-- A resolver filters, expands, and prioritizes page requests.
-- A streamer reads page blobs from cooked assets and uploads them to the physical cache.
-- Shaders sample through the page table and fall back to coarser resident mips while fine pages stream in.
+A logical virtual texture owns:
 
-Feedback should include guard bands:
+- stable texture and optional material-set identifiers;
+- logical dimensions and mip count;
+- logical interior tile size;
+- stored tile size including borders;
+- format, color space, role, and wrap policy;
+- source and cooker generation;
+- page-addressable payload descriptors;
+- an always-resident fallback mip chain or ancestor set.
 
-- texture filtering footprint
-- anisotropy
-- material UV transform
-- wrap mode
-- mip bias
-- camera velocity
-- stereo/per-eye visibility
+### Physical tile cache
 
-SVT must keep the tiered and sparse-mip paths as fallbacks. It should be opt-in per asset class until tooling and debug views are mature.
+The first production cache uses dense 2D-array texture banks:
+
+- one tile slot per array layer;
+- multiple banks when array-layer limits are reached;
+- exact fixed memory accounting;
+- per-format banks such as BC7 color, BC5 normal, BC4 scalar, and RGBA8 fallback;
+- free-list or bitmap allocation;
+- priority/LRU eviction with pinning and hysteresis;
+- deferred slot reuse until old page-table versions retire.
+
+Hardware sparse backing can be added later without changing logical page IDs or shader lookup semantics.
+
+### Virtual page table
+
+A page table maps `(texture id, layer/material-set id, mip, page x, page y)` to:
+
+- physical cache bank;
+- physical slot or array layer;
+- resolved resident mip;
+- valid and fallback state;
+- mapping generation;
+- optional format and material-set flags.
+
+Use double- or triple-buffered table publication, or an equivalent versioned scheme, so mappings consumed by submitted frames are immutable.
+
+### Feedback and resolve
+
+A feedback pass records actual sampling demand. Feedback includes or permits reconstruction of:
+
+- virtual texture and page ID;
+- requested mip;
+- sample count or screen importance;
+- view, eye, and foveation priority;
+- optional material role.
+
+A GPU resolve pass deduplicates requests, aggregates importance, expands filtering and prediction neighborhoods, and emits a bounded compact request list. CPU readback uses a staged or persistently mapped ring with intentional latency and no render-thread wait.
+
+### Page lifecycle
+
+Promotion:
+
+```text
+Requested
+→ IoQueued
+→ PayloadReady
+→ CacheSlotReserved
+→ UploadSubmitted
+→ GpuComplete
+→ MappingPublished
+→ Resident
+```
+
+Eviction:
+
+```text
+Resident
+→ AncestorMappingPublished
+→ OldTableVersionsRetired
+→ OptionalSparseUnbindComplete
+→ CacheSlotReleased
+→ Evicted
+```
+
+Failure at any stage retains a valid ancestor mapping. A partially uploaded slot is never published.
+
+### Filtering
+
+The virtual sampling helper:
+
+1. computes LOD from derivatives of the original virtual UVs;
+2. resolves the requested page or a resident ancestor;
+3. remaps UVs into the physical tile interior;
+4. uses stored borders for bilinear continuity;
+5. resolves and samples the adjacent virtual mip independently;
+6. performs virtual trilinear blending.
+
+Initial anisotropy must be capped to the footprint supported by the chosen border. Repeat, mirror, and clamp borders are generated according to authored wrap behavior. Shader-generated or unbounded UV domains opt out or use conservative fallback behavior.
+
+### VR and foveation
+
+Physical pages are shared across views. Feedback retains eye/view identity for priority analysis, but identical logical pages are unioned before streaming.
+
+Recommended order:
+
+```text
+HMD foveal samples
+> HMD peripheral samples
+> gameplay-critical auxiliary views
+> desktop mirror
+> reflections, probes, and background captures
+```
+
+The finest page required by any important view wins. Head and camera velocity expand the request neighborhood to hide feedback latency without duplicating per-eye physical caches.
+
+## Vulkan Hardware Sparse Residency
+
+True Vulkan sparse residency is an optional backend phase after dense SVT exists.
+
+Required work includes:
+
+- probe `sparseBinding`, `sparseResidencyImage2D`, and exact image format properties;
+- select a queue family with `VK_QUEUE_SPARSE_BINDING_BIT`;
+- create sparse-resident sampled images with the correct flags;
+- query normal and sparse image memory requirements;
+- implement device-local sparse block pools rather than one allocation per page;
+- bind non-tail image blocks;
+- bind opaque mip tails and implementation metadata aspects where reported;
+- order `vkQueueBindSparse` before copies through explicit semaphore dependencies;
+- publish mappings only after copy completion;
+- publish fallback mappings and retire old frames before sparse unbind and memory reuse;
+- account for bound blocks, tails, and metadata separately;
+- validate combined and dedicated sparse queues, cancellation, and device loss.
+
+Vulkan image layouts apply to image subresources rather than rectangular sparse pages. Dense 2D-array cache layers are therefore the recommended portable SVT baseline because each tile layer can transition and upload independently. Direct sparse logical images may use `VK_IMAGE_LAYOUT_GENERAL` or another proven layout strategy, but remain an advanced optimization.
 
 ## Runtime Virtual Textures
 
-Runtime virtual textures are a different feature from imported-texture SVT.
+RVT is distinct from imported-texture SVT. Its page data source is GPU rendering or compute generation rather than cooked blobs.
 
-RVT target use cases:
+Target use cases:
 
-- terrain/object blending
-- spline paths on landscapes
-- procedural terrain material caches
-- large decal projection caches
-- baked material composition for repeated landscape shading
+- terrain and object blending;
+- spline paths and roads;
+- procedural landscape material caches;
+- large decal projection caches;
+- baked repeated landscape shading.
 
-RVT should share concepts with SVT, such as page size, page residency, and debug views, but its data source is GPU rendering rather than cooked disk blobs. It belongs in a later phase after SVT page-cache infrastructure exists.
+RVT should reuse logical page IDs, physical cache banks, page-table publication, eviction, telemetry, and debug views where practical. It adds page producers, dirty-region tracking, render-work scheduling, and temporal reuse.
 
 ## Bindless Deferred Texturing
 
-Bindless deferred texturing remains the best renderer-level partner for virtual texturing.
+Bindless deferred texturing remains a useful renderer-level partner for virtual texturing.
 
 Target direction:
 
-- The opaque deferred geometry pass writes geometry data and material id instead of sampling material textures.
-- A material resolve pass fetches material data through a GPU material table.
-- Compatibility mode writes the existing `AlbedoOpacity`, `Normal`, and `RMSE` buffers so downstream lighting and decals keep working.
-- Native mode lets lighting, decals, and material modifiers consume bindless material data directly.
+- The opaque deferred geometry pass writes geometry data and material ID rather than sampling every material texture.
+- A material resolve pass fetches material records through a GPU table.
+- Compatibility mode reconstructs existing `AlbedoOpacity`, `Normal`, and `RMSE` outputs for downstream lighting and decals.
+- Native mode lets later passes consume material records and virtual texture indirection directly.
 
-The material fetch contract must be API-neutral. Vulkan can use descriptor indexing and runtime descriptor arrays. OpenGL support needs explicit extension gating for bindless handles and a fallback path that keeps the classic materialized G-buffer.
+The material fetch contract is API-neutral. Vulkan uses descriptor indexing and runtime arrays. OpenGL uses explicitly gated bindless support or retains the classic materialized G-buffer fallback.
 
-Bindless deferred should not be a prerequisite for the current texture streamer, but it will make SVT and neural feature decode much cleaner because material fetch work moves out of the overdraw-heavy geometry pass.
+Bindless deferred is not a prerequisite for v1 streaming or SVT, but it centralizes material fetch logic and makes page feedback, neural decode, and compatibility handling cleaner.
 
 ## Neural Texture Compression
 
-Neural texture compression should enter as an asset-pipeline feature, not as an ad hoc shader experiment.
+Neural texture compression enters through the asset pipeline, not as an ad hoc shader experiment.
 
 Recommended modes:
 
-1. Decode-on-load or cook-time reconstruction to conventional BCn textures. This is the first shippable path because current shaders and material bindings stay intact.
-2. Learned feature texture decode in the bindless material resolve pass. This becomes viable after bindless deferred texturing is real.
-3. High-end direct latent decode during sampling. This is experimental and requires explicit capability, project, and content opt-in.
+1. Decode-on-load or cook-time reconstruction to conventional BCn textures.
+2. Learned feature-texture decode in a bindless material resolve pass.
+3. Experimental direct latent decode on explicitly supported high-end hardware.
 
-Neural compression must remain selective. Good candidates are large terrain/material sets, repeated environment kits, and memory-dominant hero environments. It should not become the default for every texture channel.
+The cooked neural asset includes:
 
-The cooked neural asset should include:
+- source bundle hash;
+- channel conventions and color space;
+- decoder or training profile ID;
+- feature textures or latent grids;
+- decoder weights;
+- conventional fallback payloads;
+- cook-time quality metrics.
 
-- source bundle hash
-- channel conventions and color space
-- decoder/training profile id
-- feature textures or latent grids
-- decoder weights
-- prebuilt conventional fallback payloads
-- quality metrics from the cook step
+Neural compression remains selective and metric-gated. It must not become the default for every texture channel.
 
-## Vulkan Parity
+## Diagnostics And Byte Accounting
 
-Vulkan should consume the same policy and telemetry contract:
+`log_textures.txt` remains the primary runtime diagnostic surface. It should report:
 
-- desired resident size
-- desired page selection
-- committed byte estimate
-- upload priority class
-- source version
-- generation id
-- queue wait and execution timing
+- cache hit, miss, stale, fallback, write, and read timing;
+- preview and promotion queue state;
+- visibility and binding observations;
+- desired mip or page residency and transition reasons;
+- queueing, coalescing, cancellation, submission, completion, publication, and retirement;
+- storage allocation and recreation;
+- fallback binding and binding risk;
+- page faults, ancestor fallback, churn, eviction, and feedback overflow;
+- exact or estimated memory fields with explicit semantics.
 
-Vulkan-specific work belongs below the backend layer:
+Use distinct metrics:
 
-- sparse image creation and memory binding
-- transfer queue upload and barriers
-- image layout transitions
-- descriptor indexing for bindless material tables
-- residency telemetry mapped back into renderer-neutral records
+- `LogicalPayloadBytes`;
+- `EstimatedSparsePhysicalBytes` for OpenGL sparse residency;
+- `AllocatedPhysicalCacheBytes` for dense cache banks;
+- `VulkanBoundSparseBytes` for bound blocks, tails, and metadata;
+- staging and in-flight transfer bytes.
 
-OpenGL remains the first production implementation, but new policy fields should be rejected if they leak OpenGL concepts above `ITextureResidencyBackend`.
+The ImGui panel should add:
 
-## Diagnostics And Tooling
-
-`log_textures.txt` is the primary runtime diagnostic surface. It should continue to report:
-
-- cache hit/miss/stale/fallback/write/read timing
-- imported preview queue and ready states
-- visibility and material binding observations
-- desired residency and transition reasons
-- transition queueing, coalescing, cancellation, application, and finalization
-- upload chunks and slow upload events
-- storage allocation/recreation and validation failures
-- fallback binding and binding risk
-- VRAM pressure and summaries
-
-The ImGui texture streaming panel should remain the live view for:
-
-- source path and texture name
-- logical dimensions
-- resident size or base mip
-- current and desired committed bytes
-- backend
-- visibility state
-- pending transition state
-- priority score
-- queue wait
-- upload time
-- current and desired page coverage
-
-SVT and RVT add required debug views:
-
-- page-table visualization
-- physical tile cache occupancy
-- feedback heatmap
-- missing-page fallback heatmap
-- per-texture residency history
-- per-eye residency in VR
+- physical cache occupancy;
+- page-table version and visualization;
+- feedback and fault heatmaps;
+- missing-page fallback heatmap;
+- per-texture residency history;
+- per-eye/foveation demand;
+- eviction history and delayed slot reuse.
 
 ## Validation Strategy
 
-Current v1 validation must close before the next architecture leap:
+Current v1 validation must close before enabling finer residency:
 
-- cold-cache Sponza startup
-- warm-cache Sponza startup
-- low VRAM budget demotion run
-- shadow-heavy scene with pending texture promotions
-- unsupported sparse hardware or forced-tiered fallback
-- page-alignment fallback for NPOT/non-aligned textures
-- texture log schema review
-- hot-path allocation audit
+- cold- and warm-cache Sponza startup on OpenGL and Vulkan;
+- low-memory-budget demotion;
+- shadow-heavy scenes with pending promotions;
+- unsupported sparse hardware or forced dense fallback;
+- base sparse and sparse-texture2 dimension cases;
+- promotion-after-demotion;
+- stale storage generation and cancellation;
+- texture log schema and hot-path allocation audit;
+- Vulkan publication and retirement tail validation;
+- OpenGL `KHR_debug` and Vulkan validation-layer clean runs.
+
+Future hardware sparse validation adds:
+
+- OpenGL page-layout selection and edge commitments;
+- mip-tail atomic behavior;
+- exact compressed-format fallback;
+- Vulkan exact-format probing;
+- sparse block, tail, and metadata binds;
+- bind-before-copy and fallback-before-unbind dependencies;
+- dedicated and combined sparse queues;
+- device loss with outstanding sparse ownership.
 
 Future SVT validation adds:
 
-- camera sweep over a large tiled material
-- high-speed camera movement over UV-wrapped assets
-- stereo page request divergence
-- missing-page fallback visual stability
-- cache eviction under pressure
-- page feedback latency
-- physical cache fragmentation
+- bilinear and trilinear page-boundary continuity;
+- repeat, mirror, and clamp border correctness;
+- compressed block alignment;
+- oblique anisotropic surfaces;
+- camera sweeps, high-speed motion, and teleport;
+- stereo divergence and request union;
+- foveation priority changes;
+- cache exhaustion and eviction;
+- page-table generation and cache-slot reuse safety;
+- feedback overflow and latency;
+- missing-page ancestor stability;
+- exact dense-cache memory accounting.
 
 ## Risks
 
-- Sparse driver behavior differs across vendors. Keep tiered fallback mandatory.
-- Page-level sparse commits can expose black holes if the request domain is wrong. Default to full coverage until feedback or full material sampling domains are available.
-- Cooked compression can complicate sparse residency. Gate BCn sparse by `GL_ARB_sparse_texture2` and retain `Rgba8`.
-- Bindless deferred changes decal and lighting assumptions. Ship compatibility resolve first.
-- Neural compression can trade memory pressure for shader cost. Start with decode-on-load and require metric-gated rollout.
-- Runtime texture work competes with shadows, shader compilation, mesh uploads, and presentation. Shared budget telemetry is part of correctness, not just performance reporting.
+- Sparse driver behavior differs across vendors. Dense mip and dense physical-cache fallbacks remain mandatory.
+- Direct page-level sparse commitment can expose undefined or zero data when the request domain is wrong. Keep it disabled until sampling-domain or feedback correctness is proven.
+- Hardware page geometry differs from logical tile geometry. Do not bake API page shapes into portable assets.
+- OpenGL sparse physical memory is estimated, not fully observable.
+- Vulkan sparse binding, image layout, descriptor/page-table publication, and frame retirement form one ownership chain. Missing one dependency can cause stale or aliased sampling.
+- Filtering borders and virtual trilinear sampling increase stored page size and shader cost. Treat them as correctness requirements rather than optional polish.
+- Bindless deferred changes lighting and decal assumptions. Ship compatibility resolve first.
+- Neural compression trades memory pressure for decode cost and quality risk. Start with conventional reconstruction and require metrics.
+- Runtime texture work competes with shadows, shader compilation, mesh uploads, page feedback, and presentation. Shared budget telemetry is part of correctness, not merely performance reporting.

--- a/docs/work/todo/texturing/texture-runtime-streaming-virtual-texturing-todo.md
+++ b/docs/work/todo/texturing/texture-runtime-streaming-virtual-texturing-todo.md
@@ -1,20 +1,16 @@
 # Texture Runtime, Streaming, And Virtual Texturing TODO
 
-Last Updated: 2026-07-28
+Last Updated: 2026-09-02
 Status: canonical active texture residency and virtual-texturing roadmap.
-Vulkan upload/publication tail performance is governed by
-[Vulkan render-tail code changes](../rendering/vulkan-core-hardening-and-device-loss-todo.md#7-bound-shadow-streaming-and-render-thread-tail-work).
+
 Source design: [Texture Runtime, Streaming, And Virtual Texturing Design](../../design/texturing/texture-runtime-streaming-virtual-texturing-design.md)
+Backend guide: [Sparse Residency And Streaming Virtual Texturing Backend Guide](../../design/texturing/sparse-residency-and-svt-backend-guide.md)
 Compression/cache design: [Texture Compression And Cooked Texture Cache Design](../../design/texturing/texture-compression-and-cooked-cache-design.md)
 Compression/cache tracker: [Texture Compression And Cooked Texture Cache TODO](texture-compression-and-cooked-cache-todo.md)
 Validation ledger: [Texture Runtime Streaming Validation](../../testing/texture-runtime-streaming-validation.md)
+Vulkan upload/publication tail performance: [Vulkan render-tail code changes](../rendering/vulkan-core-hardening-and-device-loss-todo.md#7-bound-shadow-streaming-and-render-thread-tail-work)
 
-Ownership: this document owns residency policy, sparse/virtual texturing,
-texture metadata, compression integration, bindless texturing, and feature
-validation. Workstream 08 owns the bounded render-thread cost of Vulkan upload
-preparation/finalization, transfer and graphics queue synchronization,
-descriptor publication, retirement, and command-buffer invalidation. The
-historical Vulkan upload trackers are evidence, not parallel execution owners.
+Ownership: this document owns residency policy, OpenGL sparse residency, Vulkan sparse residency, portable SVT/RVT architecture, texture metadata, compression integration, bindless texturing, and feature validation. Workstream 08 owns the bounded render-thread cost of Vulkan upload preparation/finalization, transfer and graphics queue synchronization, descriptor publication, retirement, and command-buffer invalidation. Historical Vulkan upload trackers are evidence, not parallel execution owners.
 
 Supersedes:
 
@@ -24,7 +20,7 @@ Supersedes:
 
 ## Goal
 
-Carry the implemented texture-streaming v1 system through validation, then extend it toward safe page-level sparse residency, full streaming virtual textures, Vulkan parity, bindless deferred material resolve, and optional neural texture compression.
+Validate and harden the implemented mip-streaming runtime, then add a portable software-indirected streaming virtual texture system for OpenGL and Vulkan. Hardware sparse resources remain optional backend implementations and optimizations; they do not define the portable logical page, asset, page-table, or fallback contract.
 
 ## Current Baseline
 
@@ -35,235 +31,471 @@ Implemented today:
 - [x] `TextureResidencyPolicy` desired residency, priority, role multipliers, fairness, cooldowns, pressure fitting, and promotion fade.
 - [x] `TextureTransitionQueue` pending transition replacement, cancellation, stale repair, and lifecycle state.
 - [x] `TextureUploadScheduler` priority queueing, duplicate coalescing, generation cancellation, budget gates, and upload telemetry.
-- [x] `TextureResidencyState` for `XRTexture2D` sparse runtime fields with `SetField(...)` property mutation.
-- [x] `GLTieredTextureResidencyBackend` fallback.
-- [x] `GLSparseTextureResidencyBackend` sparse mip residency for page-aligned OpenGL `Rgba8` textures.
-- [x] Shared-context sparse promotion path with fence-gated exposure.
+- [x] `TextureResidencyState` for `XRTexture2D` runtime residency fields with `SetField(...)` property mutation.
+- [x] `GLTieredTextureResidencyBackend` dense fallback.
+- [x] `GLSparseTextureResidencyBackend` sparse whole-mip residency for eligible OpenGL `Rgba8` textures.
+- [x] OpenGL shared-context sparse promotion with fence-gated exposure and storage-generation checks.
+- [x] `VulkanDenseTextureResidencyBackend` renderer-neutral dense residency backend.
+- [x] `VulkanTextureUploadService` worker preparation, bounded staging/transfer work, generation tracking, GPU-completion-gated descriptor publication, and deferred retirement.
+- [x] Vulkan dense compatibility routing through `VulkanTextureStreamingBackendProvider`.
 - [x] Metadata-first cooked texture streamability checks.
 - [x] Cooked mip-addressable `XRTS` payload with preview mip and per-mip offsets.
 - [x] Dedicated texture logging and ImGui texture streaming diagnostics.
 
 Known current limits:
 
-- [ ] Full scene validation remains incomplete.
-- [ ] Unit-test execution is blocked by unrelated duplicate `Engine` type compile errors in the unit-test project.
-- [ ] Partial sparse page residency is scaffolded but disabled by policy.
+- [ ] Full cold/warm scene validation remains incomplete on both renderers.
+- [ ] Unit-test execution remains blocked by unrelated duplicate `Engine` type compile errors in the unit-test project.
+- [ ] OpenGL partial sparse page residency is scaffolded but disabled by policy.
+- [ ] OpenGL currently applies a conservative page-aligned base-dimension gate even when `GL_ARB_sparse_texture2` is present.
+- [ ] OpenGL sparse page-layout selection currently chooses the first usable layout rather than a documented cost-based policy.
+- [ ] OpenGL committed-byte telemetry is an estimate, not exact physical allocation reporting.
 - [ ] Cooked payloads are mip-addressable, not page-addressable.
 - [ ] Color-space and texture-role metadata are incomplete.
 - [ ] GPU-native compressed texture payloads and compressed uploads are not implemented.
-- [ ] True Vulkan sparse-image residency parity is not implemented. Dense,
-  generation-gated synchronized upload, worker preparation, transfer
-  submission, and descriptor publication exist and require final tail-latency
-  validation under workstream 08.
+- [ ] True Vulkan sparse image residency is not implemented.
+- [ ] A shared physical tile cache, virtual page table, GPU page feedback, and SVT shader sampling are not implemented.
 - [ ] Bindless deferred texturing is design-only.
 - [ ] Neural texture compression is design-only.
 
-## Phase 0: Branch, Canonical Docs, And Baseline
+## Phase 0: Canonical Documentation And Baseline
 
-**Goal:** move future texture work to one design and one todo without losing historical phase records.
+**Goal:** keep one canonical design, one execution tracker, one backend guide, and one validation ledger without losing historical implementation records.
 
-- [ ] Create a dedicated branch for this roadmap, for example `texture-runtime-vt-roadmap`.
+- [ ] Create a dedicated implementation branch for the future runtime work, for example `texture-runtime-vt-roadmap`.
 - [x] Add the canonical design doc.
 - [x] Add this canonical phased TODO.
+- [x] Add the cross-API sparse residency and SVT backend guide.
 - [x] Mark superseded texturing design docs as historical with links to the canonical design.
-- [x] Mark superseded implemented TODO docs as historical with links to this TODO and the validation ledger.
-- [x] Move implemented-TODO validation checks into the consolidated validation ledger.
-- [x] Update `docs/work/README.md` and `docs/README.md` links.
-- [ ] Preserve or link the latest texture validation logs:
-  - [ ] cold-cache Sponza run
-  - [ ] warm-cache Sponza run
-  - [ ] `log_textures.txt`
-  - [ ] `log_opengl.txt`
-  - [ ] `log_rendering.txt`
-  - [ ] profiler FPS-drop and render-stall logs
+- [x] Mark superseded implementation TODOs as historical with links to this TODO and the validation ledger.
+- [x] Move v1 validation checks into the consolidated validation ledger.
+- [x] Update `docs/work/README.md` and `docs/README.md` links for the canonical roadmap.
+- [ ] Preserve or link the latest texture validation evidence:
+  - [ ] cold-cache Sponza run;
+  - [ ] warm-cache Sponza run;
+  - [ ] `log_textures.txt`;
+  - [ ] `log_opengl.txt`;
+  - [ ] `log_vulkan.txt` where applicable;
+  - [ ] `log_rendering.txt`;
+  - [ ] profiler FPS-drop and render-stall logs.
 
-## Phase 1: Validate And Close v1 Streaming
+## Phase 1: Validate And Close V1 Mip Streaming
 
-**Goal:** prove the implemented streamer is stable before enabling finer residency.
+**Goal:** prove the implemented OpenGL and Vulkan mip streamers are stable before enabling page-level residency or SVT.
+
+### Build and unit validation
 
 - [ ] Run targeted builds:
-  - [ ] `dotnet build .\XREngine.Runtime.Rendering\XREngine.Runtime.Rendering.csproj --no-restore`
-  - [ ] `dotnet build .\XREngine.Editor\XREngine.Editor.csproj --no-restore`
-- [ ] Re-run targeted tests after the unrelated unit-test duplicate `Engine` issue is fixed:
-  - [ ] `ImportedTextureStreamingPhaseTests`
-  - [ ] `ImportedTextureStreamingContractTests`
-  - [ ] `GLTexture2DContractTests`
-  - [ ] `RuntimeRenderingHostServicesTests`
+  - [ ] `dotnet build .\XREngine.Runtime.Rendering\XREngine.Runtime.Rendering.csproj --no-restore`;
+  - [ ] `dotnet build .\XREngine.Runtime.Rendering.OpenGL\XREngine.Runtime.Rendering.OpenGL.csproj --no-restore`;
+  - [ ] `dotnet build .\XREngine.Runtime.Rendering.Vulkan\XREngine.Runtime.Rendering.Vulkan.csproj --no-restore`;
+  - [ ] `dotnet build .\XREngine.Editor\XREngine.Editor.csproj --no-restore`.
+- [ ] Re-run targeted tests after the unrelated duplicate `Engine` issue is fixed:
+  - [ ] `ImportedTextureStreamingPhaseTests`;
+  - [ ] `ImportedTextureStreamingContractTests`;
+  - [ ] `GLTexture2DContractTests`;
+  - [ ] `RuntimeRenderingHostServicesTests`;
+  - [ ] Vulkan upload/publication contract tests.
+
+### OpenGL scene validation
+
 - [ ] Run cold-cache Sponza startup and record:
-  - [ ] raw source decode count
-  - [ ] cache miss/write count
-  - [ ] first visible preview time
-  - [ ] all visible previews resident time
-  - [ ] pending visible transition drain time
-  - [ ] upload validation failure count
+  - [ ] raw source decode count;
+  - [ ] cache miss/write count;
+  - [ ] first visible preview time;
+  - [ ] all visible previews resident time;
+  - [ ] pending visible transition drain time;
+  - [ ] upload validation failure count.
 - [ ] Run warm-cache Sponza startup and record:
-  - [ ] cache hit count
-  - [ ] slow cache read count
-  - [ ] worst `cacheReadMs`
-  - [ ] worst `cacheParseMs`
-  - [ ] promotion queue wait
-  - [ ] render-thread upload chunk timings
+  - [ ] cache hit count;
+  - [ ] slow cache read count;
+  - [ ] worst `cacheReadMs`;
+  - [ ] worst `cacheParseMs`;
+  - [ ] promotion queue wait;
+  - [ ] render-thread and shared-context upload timings.
 - [ ] Confirm `Texture.UploadValidationFailed` remains zero in normal runs.
 - [ ] Confirm no texture-upload `GL_INVALID_VALUE` appears in `log_opengl.txt`.
-- [ ] Confirm `Texture.BindingRisk` entries are expected non-streaming paths or filed follow-ups.
+- [ ] Confirm promotion-after-demotion does not expose black or invalid mips.
 - [ ] Confirm `Texture.SparseStateClearedForDenseUpload` appears only for legitimate sparse-to-dense handoffs.
-- [ ] Confirm `TextureStreaming.FinalizeSparseTransitions` never waits for multi-second spans.
-- [ ] Confirm texture/shadow shared-budget counters explain any delayed promotion.
+- [ ] Confirm sparse transition finalization never blocks for multi-second spans.
+- [ ] Confirm texture/shadow shared-budget counters explain delayed promotions.
+
+### Vulkan scene validation
+
+- [ ] Run cold-cache and warm-cache imported scenes with the Vulkan renderer.
+- [ ] Confirm visible texture generations reach exact descriptor publication without a device-wide idle.
+- [ ] Confirm stale generations cancel without publishing or prematurely retiring resources.
+- [ ] Confirm worker preparation, staging, transfer batches, publication, and retirement remain bounded per frame.
+- [ ] Confirm low-memory allocation pressure defers or fails cleanly without deadlock.
+- [ ] Confirm device-loss cancellation releases or quarantines ownership correctly.
+- [ ] Complete workstream 08 Phase 2 before claiming Vulkan v1 performance closure.
+- [ ] Produce a Vulkan validation-layer-clean streaming run.
+
+### Shared diagnostics
+
+- [ ] Confirm `Texture.BindingRisk` entries are expected non-streaming paths or filed follow-ups.
 - [ ] Confirm the ImGui texture streaming panel remains responsive with hundreds of tracked textures.
-- [ ] Complete workstream 08 Phase 2 before claiming Vulkan v1 streaming
-  performance closure; this includes bounded publication/finalization cost,
-  queue/fence ownership, dirty-scope containment, and warm-zero-work proof.
+- [ ] Confirm no single upload item exceeds the configured texture budget by more than one permitted chunk.
+- [ ] Confirm memory-pressure demotion is monotonic and explained by telemetry.
 
-## Phase 2: Harden The Current Streamer
+## Phase 2: Harden The Current Streamer And Capability Model
 
-**Goal:** fix remaining v1 quality, metadata, and diagnostics gaps without changing the residency model.
+**Goal:** close metadata, capability, telemetry, and diagnostics gaps without changing the fundamental mip-residency model.
 
-- [ ] Split cache timing logs into file I/O, manifest parse, mip blob copy, CPU conversion, and GPU upload.
+### Cooked metadata and source behavior
+
+- [ ] Split cache timing logs into file I/O, manifest parse, mip blob copy, CPU conversion, GPU upload, and publication.
 - [ ] Add complete color-space metadata to the cooked texture manifest.
-- [ ] Add texture role metadata to the cooked texture manifest:
-  - [ ] albedo/base color
-  - [ ] normal/bump
-  - [ ] roughness
-  - [ ] metallic
-  - [ ] mask/opacity/alpha
-  - [ ] emissive
-  - [ ] unknown
-- [ ] Include color space and page selection in resident-data reuse cache keys where relevant.
+- [ ] Add texture role metadata:
+  - [ ] albedo/base color;
+  - [ ] normal/bump;
+  - [ ] roughness;
+  - [ ] metallic;
+  - [ ] mask/opacity/alpha;
+  - [ ] emissive;
+  - [ ] unknown.
+- [ ] Include color space, role, format, and page selection in resident-data reuse cache keys where relevant.
 - [ ] Add configurable minimum resident detail for hero assets.
 - [ ] Add adaptive decode concurrency based on CPU count, current frame time, and active import pressure.
 - [ ] Keep total decode concurrency bounded so preview urgency does not steal editor responsiveness.
-- [ ] Audit hot paths with the allocation reporting tool:
-  - [ ] registry snapshot
-  - [ ] usage recording
-  - [ ] policy scoring
-  - [ ] transition queueing
-  - [ ] scheduler submit/execute
-  - [ ] OpenGL upload chunks
+
+### OpenGL sparse capability hardening
+
+- [ ] Query and retain X/Y/Z geometry for every reported virtual page layout, not only X/Y.
+- [ ] Define a page-layout selection policy using logical tile size, page count, edge waste, format block geometry, and validation evidence.
+- [ ] Prefer a standardized sparse-texture2 index-zero layout where appropriate, but remain query-driven.
+- [ ] Distinguish base `GL_ARB_sparse_texture` allocation restrictions from `GL_ARB_sparse_texture2` arbitrary base dimensions.
+- [ ] Permit non-page-aligned base dimensions only on the sparse-texture2 path after edge-commit tests pass.
+- [ ] Keep individual page commitment origins and extents compliant with selected page geometry and mip-edge rules.
+- [ ] Replace documentation and capability assumptions that sparse compressed formats require `GL_ARB_sparse_texture2`.
+- [ ] Query exact compressed formats with `GL_NUM_VIRTUAL_PAGE_SIZES_ARB` and fall back when the result is zero.
+- [ ] Add `KHR_debug` diagnostics containing target, format, mip, rectangle, page shape/index, storage generation, and transition generation.
+- [ ] Avoid release hot-path `glGetError` polling.
+
+### Memory and telemetry semantics
+
+- [ ] Rename or document OpenGL sparse committed bytes as an estimate.
+- [ ] Add distinct telemetry for:
+  - [ ] logical payload bytes;
+  - [ ] estimated OpenGL sparse physical bytes;
+  - [ ] exact dense physical-cache bytes;
+  - [ ] exact Vulkan bound sparse bytes when implemented;
+  - [ ] staging and transfer bytes in flight.
 - [ ] Confirm `log_textures.txt` line schema is stable or document breaking changes for tooling.
-- [ ] Delete or archive obsolete partial-class files only after their active serialization/import/sparse content has moved.
-- [ ] Add diagnostic coverage for non-streaming black-surface cases that have no texture upload validation failure.
+- [ ] Add diagnostic coverage for black-surface cases that have no upload validation failure.
 
-## Phase 3: Safe Partial Sparse Page Residency
+### Allocation audit
 
-**Goal:** turn the existing partial-page scaffold into a safe optional feature.
+- [ ] Audit hot paths with the allocation reporting tool:
+  - [ ] registry snapshot;
+  - [ ] usage recording;
+  - [ ] policy scoring;
+  - [ ] transition queueing;
+  - [ ] scheduler submit/execute;
+  - [ ] OpenGL upload/finalization;
+  - [ ] Vulkan preparation/publication;
+  - [ ] diagnostics panel closed and open.
+- [ ] Delete or archive obsolete partial-class files only after active serialization/import/sparse content has moved.
 
-- [ ] Keep partial page residency disabled by default until this phase is validated.
-- [ ] Replace mesh-UV-bounds-only page requests with a material sampling domain model:
-  - [ ] UV transform
-  - [ ] wrap mode
-  - [ ] mip bias
-  - [ ] anisotropy/filter footprint
-  - [ ] normal/parallax UV perturbation policy
-  - [ ] shader-generated UV opt-out
-- [ ] Add configurable guard-band expansion around requested UV bounds.
-- [ ] Add camera-velocity and stereo guard-band expansion.
-- [ ] Track page selections per texture role if different samplers use different UV transforms.
-- [ ] Make page selection hysteresis slower than mip promotion to avoid page churn.
-- [ ] Delay uncommit of previously resident pages for a short TTL after selection changes.
+## Phase 3: Safe Optional OpenGL Partial Sparse Page Residency
+
+**Goal:** turn the existing partial-page scaffold into a safe optional bridge and diagnostic feature. This phase is not a prerequisite for portable SVT.
+
+- [ ] Keep partial sparse page residency disabled by default until this phase is validated.
+- [ ] Replace mesh-UV-bounds-only requests with a material sampling-domain model covering:
+  - [ ] UV transform;
+  - [ ] wrap mode;
+  - [ ] mip bias;
+  - [ ] anisotropy and filter footprint;
+  - [ ] normal/parallax UV perturbation policy;
+  - [ ] shader-generated UV opt-out;
+  - [ ] multiple visible instances and disjoint regions.
+- [ ] Replace the single normalized rectangle when needed with a bounded page-set representation below policy.
+- [ ] Add configurable filtering guard-band expansion.
+- [ ] Add camera/head velocity and stereo guard-band expansion.
+- [ ] Track selections per texture role when samplers use different UV transforms.
+- [ ] Make page-selection hysteresis slower than mip promotion.
+- [ ] Delay uncommit of previously resident pages through a short TTL and frame-retirement boundary.
+- [ ] Keep the complete mip tail or another valid coarse fallback pinned.
+- [ ] Never intentionally sample an uncommitted region; sparse-texture2 zero reads are not a material fallback.
 - [ ] Add page-selection telemetry:
-  - [ ] requested coverage
-  - [ ] committed coverage
-  - [ ] guard-band-expanded coverage
-  - [ ] pages committed/uncommitted this frame
-- [ ] Add tests for partial-page region math with page alignment and mip-tail behavior.
-- [ ] Add tests that partial page selection normalizes to full coverage near the full-coverage threshold.
-- [ ] Add tests for wrap-mode or out-of-range UV fallback to full coverage.
-- [ ] Validate with high-speed camera movement over wrapped and transformed UVs.
-- [ ] Enable partial page residency only behind a renderer setting after validation.
+  - [ ] requested coverage;
+  - [ ] committed coverage;
+  - [ ] guard-band-expanded coverage;
+  - [ ] pages committed/uncommitted this frame;
+  - [ ] page faults and fallback events.
+- [ ] Add tests for page-aligned region math, sparse-texture2 edge regions, and mip-tail behavior.
+- [ ] Add tests that near-full requests normalize to full coverage.
+- [ ] Add tests for repeat, mirror, clamp, out-of-range, and generated-UV fallback.
+- [ ] Validate transformed/wrapped UVs, oblique anisotropic surfaces, high-speed motion, and stereo divergence.
+- [ ] Enable only behind an explicit renderer setting after cross-vendor validation.
 
-## Phase 4: Full Streaming Virtual Textures
+## Phase 4: Portable Streaming Virtual Textures
 
-**Goal:** add SVT where only visible texture tiles need to be resident.
+**Goal:** add software-indirected SVT so only demanded logical texture tiles occupy the shared physical cache on both renderers.
+
+### 4.1 Logical asset and identity
 
 - [ ] Define a virtual texture asset model:
-  - [ ] logical dimensions
-  - [ ] logical mip count
-  - [ ] tile size
-  - [ ] border/guard texels
-  - [ ] format
-  - [ ] source version
-  - [ ] texture id
+  - [ ] stable texture ID;
+  - [ ] optional material-set/layer ID;
+  - [ ] logical dimensions;
+  - [ ] logical mip count;
+  - [ ] logical interior tile width/height;
+  - [ ] stored tile width/height including borders;
+  - [ ] border size and generation policy;
+  - [ ] format, color space, texture role, and wrap mode;
+  - [ ] source and cooker generation;
+  - [ ] always-resident fallback mip chain or ancestor set.
+- [ ] Define discrete `VirtualPageId` semantics for mip/page X/page Y/layer/source generation.
+- [ ] Support synchronized material-page bundles where base color, normal, and scalar channels should retain matching detail.
+- [ ] Keep logical tile dimensions independent of OpenGL and Vulkan hardware page geometry.
+
+### 4.2 Page-addressable cooked payload
+
 - [ ] Extend cooked texture payloads with page-addressable blobs:
-  - [ ] per-page offsets
-  - [ ] per-page byte lengths
-  - [ ] per-page format/block metadata
-  - [ ] optional compression
-  - [ ] fallback mip chain
-- [ ] Implement a physical tile cache:
-  - [ ] fixed GPU memory budget
-  - [ ] tile allocation table
-  - [ ] free list
-  - [ ] LRU/priority eviction
-  - [ ] per-format pools or a documented single-format first pass
-- [ ] Implement a virtual page table:
-  - [ ] CPU representation
-  - [ ] GPU texture/buffer representation
-  - [ ] fallback-to-coarser-page encoding
-  - [ ] update batching
-- [ ] Add a feedback pass:
-  - [ ] texture id
-  - [ ] requested mip
-  - [ ] page x/y
-  - [ ] screen coverage or sample count
-  - [ ] per-eye id for VR
-- [ ] Add feedback resolve:
-  - [ ] deduplicate requests
-  - [ ] expand guard bands
-  - [ ] prioritize visible/high-error pages
-  - [ ] keep coarse fallback pages resident
-- [ ] Add page streaming:
-  - [ ] async page blob reads
-  - [ ] upload queue integration
-  - [ ] generation cancellation
-  - [ ] stale request cancellation
-  - [ ] partial update batching
-- [ ] Add shader sampling helpers for page-table lookup and physical tile sampling.
-- [ ] Add fallback path to sparse mip residency or tiered residency when SVT is unsupported.
+  - [ ] page identity;
+  - [ ] per-page offsets and byte lengths;
+  - [ ] per-page format and compression block metadata;
+  - [ ] stored row/slice metadata;
+  - [ ] checksums/content hashes;
+  - [ ] source/cook version;
+  - [ ] fallback mip descriptors.
+- [ ] Generate wrap-aware borders before GPU-native compression:
+  - [ ] repeat;
+  - [ ] mirror;
+  - [ ] clamp.
+- [ ] Keep stored dimensions and offsets block-aligned for BCn payloads.
+- [ ] Add page-group metadata for material bundles where useful.
+- [ ] Validate metadata-first page selection without hydrating unrelated blobs.
+
+### 4.3 Physical tile cache
+
+- [ ] Implement a globally budgeted physical cache using dense 2D-array texture banks first.
+- [ ] Allocate one tile slot per array layer and multiple banks when layer limits are reached.
+- [ ] Implement per-format or per-role pools:
+  - [ ] BC7/sRGB and linear color;
+  - [ ] BC5 normals;
+  - [ ] BC4 scalar data;
+  - [ ] RGBA8 portable fallback.
+- [ ] Implement slot allocation, free lists/bitmaps, ownership generation, and pin state.
+- [ ] Implement LRU/priority eviction with fairness, hysteresis, and minimum TTL.
+- [ ] Track exact cache allocation and live slot occupancy.
+- [ ] Prevent slot reuse until all page-table versions that reference the old owner retire.
+- [ ] Keep hardware-sparse cache backing as a later optional backend.
+
+### 4.4 Virtual page table
+
+- [ ] Define a packed API-neutral page-table entry containing:
+  - [ ] valid/resident state;
+  - [ ] physical cache bank;
+  - [ ] physical slot/layer;
+  - [ ] resolved resident mip;
+  - [ ] ancestor/fallback delta;
+  - [ ] mapping generation;
+  - [ ] optional format/material-set flags.
+- [ ] Implement a CPU shadow representation.
+- [ ] Implement OpenGL and Vulkan GPU representations using integer textures or buffers according to measured performance.
+- [ ] Add update batching and dirty-range tracking.
+- [ ] Add double/triple buffering or equivalent versioned publication.
+- [ ] Ensure submitted frames observe immutable page-table versions.
+- [ ] Publish ancestor mappings before eviction and slot reuse.
+
+### 4.5 Page streaming lifecycle
+
+- [ ] Implement the promotion lifecycle:
+  - [ ] `Requested`;
+  - [ ] `IoQueued`;
+  - [ ] `PayloadReady`;
+  - [ ] `CacheSlotReserved`;
+  - [ ] `UploadSubmitted`;
+  - [ ] `GpuComplete`;
+  - [ ] `MappingPublished`;
+  - [ ] `Resident`.
+- [ ] Implement the eviction lifecycle:
+  - [ ] `Resident`;
+  - [ ] `AncestorMappingPublished`;
+  - [ ] `OldTableVersionsRetired`;
+  - [ ] optional sparse unbind complete;
+  - [ ] `CacheSlotReleased`;
+  - [ ] `Evicted`.
+- [ ] Integrate async page reads with generation cancellation and stale-request cancellation.
+- [ ] Reuse existing OpenGL shared-context/PBO and Vulkan staging/transfer/publication infrastructure.
+- [ ] Batch uploads and page-table updates under shared render-work budgets.
+- [ ] Never publish partially uploaded slots.
+
+### 4.6 Shader sampling and filtering
+
+- [ ] Add shared GLSL/SPIR-V virtual texture sampling helpers.
+- [ ] Compute LOD from derivatives of original virtual UVs.
+- [ ] Resolve requested pages or valid resident ancestors.
+- [ ] Remap UVs into the physical tile interior.
+- [ ] Use stored borders for bilinear continuity.
+- [ ] Resolve both adjacent virtual mips and implement virtual trilinear blending.
+- [ ] Establish an initial maximum anisotropy supported by the border width.
+- [ ] Add fallback or opt-out for generated, unbounded, or unsupported UV domains.
+- [ ] Ensure normal and scalar fallback values remain semantically valid through ancestor sampling.
+
+### 4.7 GPU feedback and resolve
+
+- [ ] Implement an initial feedback path using a reduced integer target, storage-buffer hash/bitset, or material resolve output.
+- [ ] Include or reconstruct:
+  - [ ] virtual page ID;
+  - [ ] requested mip;
+  - [ ] sample count/screen coverage;
+  - [ ] eye/view/foveation priority;
+  - [ ] optional texture role.
+- [ ] Implement GPU request deduplication, aggregation, and bounded compaction.
+- [ ] Add overflow detection and deterministic degradation.
+- [ ] Read compact feedback through a multi-frame mapped/staged ring with no render-thread wait.
+- [ ] Add guard-band and neighborhood expansion.
+- [ ] Add camera/head linear and angular velocity prediction.
+- [ ] Add starvation prevention across assets and material bundles.
+- [ ] Handle camera teleports by preferring valid coarse fallback over an unbounded page flood.
+
+### 4.8 VR and multi-view behavior
+
+- [ ] Carry eye/view/foveation identity through feedback for priority analysis.
+- [ ] Union identical logical page requests across both eyes before physical streaming.
+- [ ] Select the finest page demanded by any important view.
+- [ ] Prioritize:
+  - [ ] HMD foveal;
+  - [ ] HMD peripheral;
+  - [ ] gameplay-critical auxiliary cameras;
+  - [ ] desktop mirror;
+  - [ ] reflections/probes/background captures.
+- [ ] Expand prediction neighborhoods for head rotation and gaze/foveation motion.
+- [ ] Do not create duplicate per-eye physical caches.
+
+### 4.9 Debugging and validation
+
 - [ ] Add debug views:
-  - [ ] physical cache occupancy
-  - [ ] page table
-  - [ ] feedback heatmap
-  - [ ] missing-page fallback
-  - [ ] eviction history
-- [ ] Validate with large 16k-style test textures and camera sweeps.
-- [ ] Validate per-eye page residency in VR before enabling SVT for stereo views.
+  - [ ] physical cache occupancy;
+  - [ ] page table and version;
+  - [ ] feedback heatmap;
+  - [ ] missing-page/ancestor fallback heatmap;
+  - [ ] eviction and delayed slot-reuse history;
+  - [ ] per-eye/foveation demand.
+- [ ] Add telemetry for page faults, fallback rate, upload latency, churn, evictions, cache hit rate, feedback overflow, and predicted versus requested pages.
+- [ ] Validate with 16k and larger virtual textures, camera sweeps, high-speed motion, and teleport.
+- [ ] Validate repeat/mirror/clamp borders, bilinear/trilinear seams, compressed block alignment, and oblique anisotropic surfaces.
+- [ ] Validate cache exhaustion and old page-table versions referencing retired slots.
+- [ ] Validate stereo divergence, request union, and foveated priority before enabling SVT for VR content.
+- [ ] Keep dense mip and OpenGL sparse-mip fallbacks for nonvirtualized or unsupported assets.
 
-## Phase 5: Vulkan Texture Residency Parity
+## Phase 5A: Vulkan Dense Streaming Closure
 
-**Goal:** bring the renderer-neutral streaming policy to Vulkan without leaking Vulkan details above the backend.
+**Goal:** validate and document the already implemented Vulkan dense mip-streaming backend before adding true sparse residency.
 
-- [ ] Implement a Vulkan `ITextureResidencyBackend`.
-- [ ] Add staged image upload integration with `TextureUploadScheduler`.
-- [ ] Add generation-gated cancellation for Vulkan image storage changes.
-- [ ] Add Vulkan sparse image capability probes.
-- [ ] Add Vulkan sparse image allocation/binding path where supported.
-- [ ] Add Vulkan fallback to dense tiered residency.
-- [ ] Route upload telemetry through `TextureRuntimeTelemetry`.
-- [ ] Add descriptor update strategy for streamed texture changes.
-- [ ] Add barrier/layout transition coverage for partial image updates.
-- [ ] Add tests or source-contract checks that no Vulkan/OpenGL handles leak above the backend interface.
-- [ ] Validate Vulkan warm-cache imported scene startup.
+Implemented in source:
+
+- [x] `VulkanDenseTextureResidencyBackend` implements `ITextureResidencyBackend`.
+- [x] Metadata-first selected-mip loading and resident-data reuse.
+- [x] Worker-side Vulkan image/staging preparation.
+- [x] Generation-gated synchronized upload admission.
+- [x] Bounded staging and transfer chunking.
+- [x] Transfer/graphics submission and completion polling.
+- [x] GPU-completion-gated descriptor publication.
+- [x] Publication authority and exact-generation checks.
+- [x] Staging and old-image resource retirement.
+- [x] Dense fallback/provider routing.
+- [x] Upload, queue, timing, publication, cancellation, and failure telemetry.
+
+Remaining closure work:
+
+- [ ] Validate warm-cache imported scene startup.
+- [ ] Validate bounded preparation, transfer, completion, publication, and retirement tail cost.
+- [ ] Validate exact frame-readiness behavior for visible textures.
+- [ ] Validate stale-generation cancellation at every lifecycle state.
+- [ ] Validate low-memory allocation-pressure retries.
+- [ ] Validate graphics-queue fallback where no separate transfer path is available.
+- [ ] Validate device loss with preparation, transfer, and publication work in flight.
+- [ ] Confirm no Vulkan/OpenGL handles leak above renderer-neutral backend interfaces.
+- [ ] Produce validation-layer-clean evidence and link it from the validation ledger.
+
+## Phase 5B: Vulkan Hardware Sparse Residency
+
+**Goal:** add true Vulkan sparse image binding without changing the renderer-neutral logical page or SVT contracts.
+
+### Capabilities and queues
+
+- [ ] Probe `sparseBinding` and `sparseResidencyImage2D`.
+- [ ] Probe `shaderResourceResidency` only for optional residency-query shaders.
+- [ ] Select at least one queue family with `VK_QUEUE_SPARSE_BINDING_BIT`.
+- [ ] Support both combined graphics/sparse and dedicated sparse queue families.
+- [ ] Query exact format/type/tiling/usage/sample-count support with `vkGetPhysicalDeviceSparseImageFormatProperties2`.
+- [ ] Fall back to dense residency when the exact image configuration returns no sparse properties.
+
+### Images and memory pools
+
+- [ ] Create sampled sparse images with:
+  - [ ] `VK_IMAGE_CREATE_SPARSE_BINDING_BIT`;
+  - [ ] `VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT`;
+  - [ ] sampled and transfer-destination usage;
+  - [ ] optimal tiling where supported.
+- [ ] Query normal and sparse image memory requirements.
+- [ ] Implement device-local sparse block pools by compatible memory type.
+- [ ] Do not allocate one `VkDeviceMemory` object per page.
+- [ ] Track block owner, generation, pending bind/unbind state, and deferred reclamation.
+- [ ] Bind non-tail regions with `VkSparseImageMemoryBindInfo`.
+- [ ] Bind opaque mip tails with `VkSparseImageOpaqueMemoryBindInfo`.
+- [ ] Handle single and per-array-layer mip tails.
+- [ ] Bind implementation metadata aspects with `VK_SPARSE_MEMORY_BIND_METADATA_BIT` where reported.
+- [ ] Account exactly for bound blocks, mip tails, and metadata allocations.
+
+### Synchronization and publication
+
+- [ ] Implement explicit bind-to-copy ordering:
+  - [ ] reserve physical blocks;
+  - [ ] submit `vkQueueBindSparse`;
+  - [ ] signal bind-complete semaphore/timeline value;
+  - [ ] make transfer/graphics copy wait for bind completion;
+  - [ ] signal upload completion;
+  - [ ] publish LOD/page-table state only after upload completion.
+- [ ] Keep dependencies explicit even when bind and copy use the same queue.
+- [ ] Define image layout strategy for direct sparse images.
+- [ ] Prefer dense 2D-array SVT cache layers for portable per-tile transitions.
+- [ ] Implement fallback publication before unbind:
+  - [ ] publish ancestor/coarser mapping;
+  - [ ] retire frames that can see the old mapping;
+  - [ ] submit null-memory sparse unbind;
+  - [ ] wait for unbind completion;
+  - [ ] return blocks to the pool.
+- [ ] Add cancellation and stale-generation handling while bind/copy/unbind work is in flight.
+- [ ] Add device-loss ownership cleanup or quarantine rules.
+
+### Tests and validation
+
+- [ ] Add source-contract tests for capability and fallback boundaries.
+- [ ] Test non-tail binds, edge blocks, mip tails, metadata binds, and array layers.
+- [ ] Test bind-before-copy and upload-before-publication ordering.
+- [ ] Test fallback-before-unbind and block-reuse ordering.
+- [ ] Test dedicated and combined sparse queue configurations.
+- [ ] Test exact bound-byte accounting under promotion/demotion pressure.
+- [ ] Produce validation-layer-clean sparse runs on supported hardware.
+- [ ] Keep the dense Vulkan backend mandatory as fallback.
 
 ## Phase 6: Bindless Deferred Texturing
 
-**Goal:** move opaque deferred material texture sampling out of the geometry pass.
+**Goal:** move opaque deferred material texture sampling out of the geometry pass and provide a clean integration point for virtual-texture feedback and neural decode.
 
 - [ ] Finalize an API-neutral deferred material record.
 - [ ] Populate real texture handles/indices in `GPUMaterialTable`.
 - [ ] Add Vulkan descriptor-indexed material texture arrays.
 - [ ] Add OpenGL bindless texture support with explicit extension gating.
-- [ ] Keep a classic materialized G-buffer fallback path.
+- [ ] Keep a classic materialized G-buffer fallback.
 - [ ] Add geometry-only deferred attachments:
-  - [ ] depth
-  - [ ] packed tangent frame or normal basis
-  - [ ] UV0
-  - [ ] depth/UV gradients as needed
-  - [ ] material id
-  - [ ] transform id
-- [ ] Add compatibility material resolve pass that reconstructs `AlbedoOpacity`, `Normal`, and `RMSE`.
+  - [ ] depth;
+  - [ ] packed tangent frame or normal basis;
+  - [ ] UV0;
+  - [ ] depth/UV gradients as needed;
+  - [ ] material ID;
+  - [ ] transform ID.
+- [ ] Add a compatibility material resolve pass that reconstructs `AlbedoOpacity`, `Normal`, and `RMSE`.
 - [ ] Keep deferred decals working against reconstructed buffers in compatibility mode.
+- [ ] Add texture residency gates so material records never reference invalid dense, sparse, or virtual data.
+- [ ] Integrate SVT feedback generation with the material resolve path where useful.
 - [ ] Add native bindless lighting mode after compatibility mode is stable.
-- [ ] Add texture streaming residency gates so bindless material records never reference invalid texture data.
 - [ ] Validate non-stereo opaque deferred first.
 - [ ] Add MSAA, stereo, transparent, and forward-only follow-ups after the core path is stable.
 
@@ -272,48 +504,66 @@ Known current limits:
 **Goal:** add optional neural material compression through the asset pipeline.
 
 - [ ] Define a canonical neural-eligible material bundle:
-  - [ ] base color
-  - [ ] tangent normal
-  - [ ] roughness
-  - [ ] metallic
-  - [ ] ambient occlusion
-  - [ ] emissive
-  - [ ] color-space metadata
-  - [ ] mip policy
+  - [ ] base color;
+  - [ ] tangent normal;
+  - [ ] roughness;
+  - [ ] metallic;
+  - [ ] ambient occlusion;
+  - [ ] emissive;
+  - [ ] color-space metadata;
+  - [ ] mip/page policy.
 - [ ] Add `XRNeuralMaterialAsset` and cook settings.
 - [ ] Add an offline training/optimization tool under `Tools/`.
 - [ ] Add metric output:
-  - [ ] per-channel error
-  - [ ] perceptual image diff
-  - [ ] normal angular error
-  - [ ] frame-space material diff captures
+  - [ ] per-channel error;
+  - [ ] perceptual image difference;
+  - [ ] normal angular error;
+  - [ ] frame-space material comparison captures.
 - [ ] Ship decode-on-load or cook-time reconstruction to conventional BCn first.
-- [ ] Require owner approval and dependency/license review before adding compression/training dependencies.
-- [ ] Integrate neural fallback textures with the existing streaming cache.
+- [ ] Require owner approval and dependency/license review before adding compression or training dependencies.
+- [ ] Integrate conventional neural fallback textures with the current mip streamer and future SVT cache.
 - [ ] Add feature-texture shader decode only after bindless deferred resolve is stable.
 - [ ] Add direct latent decode only as an explicit high-end experimental path.
 
 ## Phase 8: Runtime Virtual Textures
 
-**Goal:** add GPU-generated virtual texture pages for terrain, decals, and procedural material caches.
+**Goal:** add GPU-generated virtual texture pages for terrain, decals, splines, and procedural material caches after SVT cache ownership is stable.
 
-- [ ] Define RVT page producer interface.
-- [ ] Add terrain and landscape page producer.
-- [ ] Add decal/spline projection producer.
-- [ ] Share page cache concepts with SVT where practical.
+- [ ] Define an RVT page-producer interface.
+- [ ] Add terrain/landscape page producers.
+- [ ] Add decal and spline projection producers.
+- [ ] Reuse SVT page IDs, physical caches, page tables, publication, and eviction where practical.
 - [ ] Add dirty-region tracking.
 - [ ] Add page render scheduling under the shared render-work budget.
 - [ ] Add page invalidation and temporal reuse.
+- [ ] Add producer generation and stale-work cancellation.
 - [ ] Add fallback when RVT page generation misses the current frame.
-- [ ] Validate terrain-object blend and large decal cases.
+- [ ] Validate terrain-object blending and large decal cases.
 
 ## Phase 9: Stable Documentation And Closeout
 
-**Goal:** move durable texture architecture into stable docs once the roadmap phases settle.
+**Goal:** promote durable architecture into stable guides after implementation and validation settle.
 
-- [ ] Promote the final runtime texture architecture into `docs/architecture/rendering/` or `docs/developer-guides/`.
-- [ ] Keep historical TODOs as phase ledgers only.
-- [ ] Update `docs/architecture/rendering/default-render-pipeline-notes.md` if bindless or virtual-texture paths change render-pass invariants.
-- [ ] Update user-facing setup docs if new settings, launch flags, cache formats, or diagnostics workflows are added.
-- [ ] Refresh dependency docs and licenses after any compression/tooling dependency change.
-- [ ] Merge the dedicated roadmap branch back into `main` after validation and owner review.
+- [ ] Keep the canonical design, backend guide, TODO, and validation ledger synchronized.
+- [ ] Promote final runtime texture architecture into `docs/architecture/rendering/` or `docs/developer-guides/`.
+- [ ] Keep historical TODOs and design plans as ledgers only.
+- [ ] Update `docs/architecture/rendering/default-render-pipeline-notes.md` when bindless or virtual-texture paths change pass invariants.
+- [ ] Update user-facing setup docs for settings, flags, cache formats, and diagnostics.
+- [ ] Refresh dependency and license docs after any compression/tooling dependency change.
+- [ ] Link final OpenGL, Vulkan dense, Vulkan sparse, and SVT validation evidence.
+- [ ] Merge the dedicated implementation branch after owner review.
+
+### Documentation acceptance criteria
+
+- [ ] “Virtual texturing” is never used as a synonym for sparse whole-mip residency.
+- [ ] Sparse compressed-format support is described as exact-format query-driven, not as universally requiring `GL_ARB_sparse_texture2`.
+- [ ] The implemented Vulkan dense backend is documented separately from future Vulkan sparse residency.
+- [ ] Every promotion sequence publishes only after memory binding and GPU upload completion.
+- [ ] Every eviction sequence revokes mappings before physical memory reuse.
+- [ ] No portable path depends on nonresident hardware sparse read values.
+- [ ] Logical tile dimensions remain independent of API hardware page dimensions.
+- [ ] OpenGL mip-tail and Vulkan mip-tail/metadata behavior are documented.
+- [ ] Filtering borders, virtual trilinear sampling, wrap behavior, and initial anisotropy limits are part of the SVT contract.
+- [ ] Stereo feedback is unioned rather than creating duplicate physical pages.
+- [ ] Both renderers retain explicit dense fallbacks for unsupported capabilities.
+- [ ] Every memory field is labeled exact or estimated according to backend observability.


### PR DESCRIPTION
## Summary

- add a normative OpenGL/Vulkan sparse-residency and streaming virtual texturing backend guide
- distinguish dense mip streaming, hardware sparse mip/page residency, SVT, and RVT
- document correct OpenGL sparse allocation, page-layout, mip-tail, promotion/demotion, compressed-format, and synchronization rules
- document the future Vulkan sparse image capability, memory-pool, mip-tail/metadata, bind/copy/publication, unbind, and layout contracts
- establish dense 2D-array physical cache banks plus a versioned virtual page table as the portable OpenGL/Vulkan SVT baseline
- define page lifecycle, filtering borders, virtual trilinear sampling, feedback, cache-slot retirement, and VR/foveation request union
- update the canonical design to accurately describe the existing Vulkan dense streaming implementation
- split the roadmap into Vulkan dense-streaming closure and future Vulkan hardware-sparse phases
- expand the SVT TODO into concrete asset, cooker, cache, page-table, upload, feedback, shader, VR, diagnostics, and validation work

## Important corrections

- sparse immutable OpenGL storage must be configured before storage allocation
- `GL_ARB_sparse_texture2` permits arbitrary base dimensions, while individual commitments still obey page and mip-edge rules
- sparse compressed-format support is exact-format query-driven and does not universally require `GL_ARB_sparse_texture2`
- nonresident sparse reads are not a valid material fallback
- hardware page geometry must not define the portable cooked logical tile size
- `vkQueueBindSparse` requires an explicit bind-to-copy-to-publication dependency chain

## Scope

Documentation only. No runtime, renderer, shader, build, asset, or test code is changed.

## Validation

- compared `docs/sparse-residency-svt-guidance` against `master`
- confirmed the branch is based directly on current `master`
- confirmed all changed paths are Markdown files under `docs/work/design/texturing` or `docs/work/todo/texturing`
- reviewed links between the canonical design, backend guide, roadmap, compression design, and validation ledger

## Changed documents

- `docs/work/design/texturing/sparse-residency-and-svt-backend-guide.md`
- `docs/work/design/texturing/texture-runtime-streaming-virtual-texturing-design.md`
- `docs/work/todo/texturing/texture-runtime-streaming-virtual-texturing-todo.md`